### PR TITLE
feat: complete Gemini stats pipeline — Groups 4-6 finalization

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -333,6 +333,7 @@ async function runQuery(opts: CliOptions): Promise<void> {
       web_search_calls: result.geminiCounts?.webSearch,
       fetch_url_calls: result.geminiCounts?.fetchUrl,
       code_executions_server_side: result.geminiCounts?.codeExecutionsServerSide,
+      image_generations: result.geminiCounts?.generateImage,
     });
     // For JSON output, stats are included in the response
     if (opts.output === "json") {

--- a/src/output.ts
+++ b/src/output.ts
@@ -38,6 +38,7 @@ export interface GeminiStatsData {
   web_search_calls: number;
   fetch_url_calls: number;
   code_executions_server_side: number;
+  image_generations: number;
 }
 
 /** Stats data emitted via --stats. */
@@ -106,6 +107,7 @@ export function buildStats(
     web_search_calls?: number;
     fetch_url_calls?: number;
     code_executions_server_side?: number;
+    image_generations?: number;
   }
 ): StatsData {
   const stats: StatsData = {
@@ -131,11 +133,15 @@ export function buildStats(
   }
 
   // Include Gemini stats when any Gemini features were used
-  if (
+  const hasGeminiActivity =
     meta.thinking_level ||
     (meta.gemini_batteries_used && meta.gemini_batteries_used.length > 0) ||
-    (meta.thought_signatures_circulated && meta.thought_signatures_circulated > 0)
-  ) {
+    (meta.thought_signatures_circulated && meta.thought_signatures_circulated > 0) ||
+    (meta.web_search_calls && meta.web_search_calls > 0) ||
+    (meta.fetch_url_calls && meta.fetch_url_calls > 0) ||
+    (meta.code_executions_server_side && meta.code_executions_server_side > 0) ||
+    (meta.image_generations && meta.image_generations > 0);
+  if (hasGeminiActivity) {
     stats.gemini = {
       thinking_level: meta.thinking_level ?? null,
       gemini_batteries_used: meta.gemini_batteries_used ?? [],
@@ -143,6 +149,7 @@ export function buildStats(
       web_search_calls: meta.web_search_calls ?? 0,
       fetch_url_calls: meta.fetch_url_calls ?? 0,
       code_executions_server_side: meta.code_executions_server_side ?? 0,
+      image_generations: meta.image_generations ?? 0,
     };
   }
 

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -364,6 +364,7 @@ export async function rlmLoop(
       // Handle server-side code execution results from Gemini (GROUP 5)
       // These are executed by Gemini's code_execution tool and returned in the response
       if (response.codeExecutionResults && response.codeExecutionResults.length > 0) {
+        geminiCounts.codeExecutionsServerSide += response.codeExecutionResults.length;
         if (opts.verbose) {
           logVerbose(iteration, `received ${response.codeExecutionResults.length} server-side execution results`);
         }

--- a/tests/gemini-stats.test.ts
+++ b/tests/gemini-stats.test.ts
@@ -69,6 +69,34 @@ describe("Gemini stats in buildStats", () => {
     assert.equal(stats.gemini.code_executions_server_side, 2);
   });
 
+  it("includes image generation count", () => {
+    const stats = buildStats(BASE_RESULT, {
+      time_ms: 1000,
+      thinking_level: "low",
+      image_generations: 3,
+    });
+    assert.ok(stats.gemini);
+    assert.equal(stats.gemini.image_generations, 3);
+  });
+
+  it("triggers gemini stats on web_search_calls alone", () => {
+    const stats = buildStats(BASE_RESULT, {
+      time_ms: 1000,
+      web_search_calls: 2,
+    });
+    assert.ok(stats.gemini);
+    assert.equal(stats.gemini.web_search_calls, 2);
+  });
+
+  it("triggers gemini stats on code_executions_server_side alone", () => {
+    const stats = buildStats(BASE_RESULT, {
+      time_ms: 1000,
+      code_executions_server_side: 1,
+    });
+    assert.ok(stats.gemini);
+    assert.equal(stats.gemini.code_executions_server_side, 1);
+  });
+
   it("includes both cache and gemini stats simultaneously", () => {
     const resultWithCache: RLMResult = {
       ...BASE_RESULT,


### PR DESCRIPTION
## Summary
- Track server-side code execution count (`geminiCounts.codeExecutionsServerSide`) in `rlm.ts` when Gemini `code_execution` tool returns results
- Add `image_generations` field to `GeminiStatsData` and `buildStats` pipeline
- Broaden gemini stats trigger: any call count (web_search, fetch_url, code_executions, image_generations) now activates the gemini stats block
- Pass `image_generations` from `cli.ts` to `buildStats`
- Add 3 new tests: image generation count, web_search-only trigger, code_execution-only trigger (142 tests total)

Follows up on PR #9 which merged the core v0.4.0 implementation.

## Test plan
- [x] `npm run build` — clean TypeScript compilation
- [x] `npm test` — 142 tests pass (0 failures)
- [x] New tests verify Gemini stats trigger on each call type independently