### PR TITLE
fix(context): resolve symlinked directories and files

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -25,11 +25,21 @@ async function collectFiles(
 
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
+
+    // Resolve symlinks: isDirectory/isFile return false for symlinks
+    let isDir = entry.isDirectory();
+    let isFile = entry.isFile();
+    if (entry.isSymbolicLink()) {
+      const resolved = await stat(fullPath); // stat follows symlinks
+      isDir = resolved.isDirectory();
+      isFile = resolved.isFile();
+    }
+
+    if (isDir) {
       if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
       const subItems = await collectFiles(fullPath, baseDir, ext);
       items.push(...subItems);
-    } else if (entry.isFile() && entry.name.endsWith(ext)) {
+    } else if (isFile && entry.name.endsWith(ext)) {
       const content = await readFile(fullPath, "utf-8");
       items.push({
         path: relative(baseDir, fullPath),


### PR DESCRIPTION
## Summary
- `collectFiles()` now follows symlinks when scanning context directories
- Fixes #15 — directories/files behind symlinks were silently skipped

## Problem
`readdir({ withFileTypes: true })` returns Dirent objects where `isDirectory()` and `isFile()` return `false` for symbolic links. This caused `--context /path/with/symlinks/` to return 0 items.

Common in production: our vault system at `/home/genie/vaults/*` uses symlinks to actual brain directories.

## Fix
Check `entry.isSymbolicLink()` and resolve via `stat(fullPath)` (which follows symlinks) before the `isDirectory`/`isFile` branch. 1 file, 12 insertions, 2 deletions.

## Test plan
- [x] `npm run build` passes
- [x] Manual test: created dir with symlinked subdir + .md file → both found (2 items)
- [x] Production test: `/home/genie/vaults/vegapunk/` (6 symlinked subdirs) → 31 items loaded correctly