### PR TITLE
fix: apply context.exclude in all CLI paths (#16)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -278,7 +278,7 @@ async function runQuery(opts: CliOptions): Promise<void> {
   if (opts.context) {
     const contextPath = resolve(opts.context);
     const contextOpts = opts.ext
-      ? { extensions: opts.ext }
+      ? { extensions: opts.ext, exclude: config.contextConfig?.exclude }
       : config.contextConfig
         ? { extensions: config.contextConfig.extensions, exclude: config.contextConfig.exclude }
         : undefined;
@@ -380,7 +380,11 @@ async function runCache(opts: CliOptions): Promise<void> {
 
   // Load context
   const contextPath = resolve(opts.context);
-  const contextOpts = opts.ext ? { extensions: opts.ext } : undefined;
+  const contextOpts = opts.ext
+    ? { extensions: opts.ext, exclude: config.contextConfig?.exclude }
+    : config.contextConfig
+      ? { extensions: config.contextConfig.extensions, exclude: config.contextConfig.exclude }
+      : undefined;
   const context = await loadContext(contextPath, contextOpts);
 
   // Validate context size
@@ -469,7 +473,11 @@ async function runBatchCommand(opts: CliOptions): Promise<void> {
   let context = null;
   if (opts.context) {
     const contextPath = resolve(opts.context);
-    const contextOpts = opts.ext ? { extensions: opts.ext } : undefined;
+    const contextOpts = opts.ext
+      ? { extensions: opts.ext, exclude: config.contextConfig?.exclude }
+      : config.contextConfig
+        ? { extensions: config.contextConfig.extensions, exclude: config.contextConfig.exclude }
+        : undefined;
     context = await loadContext(contextPath, contextOpts);
     if (opts.verbose) {
       console.error(`rlmx batch: loaded context — ${context.metadata}`);


### PR DESCRIPTION
## Summary

- `context.exclude` from rlmx.yaml was silently dropped when `--ext` overrode extensions in `runQuery`
- `runCache` and `runBatch` never read `config.contextConfig` at all — exclude rules were completely ignored
- All 3 call sites now consistently merge exclude from config, regardless of `--ext` flag

Closes #16

## Test plan

- [ ] `rlmx "query" --context ./path --ext .md,.txt` with exclude rules in rlmx.yaml → excluded dirs should not appear in loaded context
- [ ] `rlmx cache --context ./path` → same exclude behavior as query
- [ ] `rlmx batch questions.txt --context ./path` → same exclude behavior
- [ ] No rlmx.yaml → defaults still work (no regression)
- [ ] `npx tsc --noEmit` passes