### PR TITLE
feat: add soft iteration limit to prevent hard truncation (#17, #18)

### DIFF
--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -453,6 +453,22 @@ export async function rlmLoop(
         });
       }
 
+      // Soft iteration limit: nudge LLM to wrap up when approaching max
+      const remaining = opts.maxIterations - iteration - 1;
+      if (opts.maxIterations >= 5 && remaining <= 2 && remaining > 0) {
+        if (opts.verbose) {
+          logVerbose(iteration, `soft limit: ${remaining} iteration(s) remaining, nudging LLM to wrap up`);
+        }
+        const nudge = remaining === 2
+          ? "\n\nNote: You have 2 iterations remaining. Start wrapping up your analysis and prepare your final answer."
+          : "\n\nNote: This is your LAST iteration. Provide your final answer NOW using FINAL().";
+        // Append nudge to the last user message
+        const lastMsg = messages[messages.length - 1];
+        if (lastMsg.role === "user") {
+          lastMsg.content += nudge;
+        }
+      }
+
       // Emit stream event if in stream mode
       if (opts.output === "stream") {
         emitStreamEvent({


### PR DESCRIPTION
## Summary

- Inject wrap-up nudge when approaching max-iterations:
  - At `maxIterations - 2`: "You have 2 iterations remaining..."
  - At `maxIterations - 1`: "This is your LAST iteration..."
- Only activates when `maxIterations >= 5`
- Logged in verbose mode

Previously the LLM was hard-cut with no warning, producing truncated analysis on complex multi-step tasks.

Closes #17, closes #18

## Test plan

- [ ] Run with `--max-iterations 10` → verify nudge appears at iter 8 and 9
- [ ] Run with `--max-iterations 3` → no nudge (below threshold)
- [ ] Run that finishes before soft limit → no nudge
- [ ] `--verbose` logs soft limit activation
- [ ] `npx tsc --noEmit` passes