### PR TITLE
perf: eliminate hot-path allocations in RLM loop

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -23,31 +23,36 @@ const DEFAULT_COLLECT_OPTIONS: CollectOptions = {
 };
 
 /**
- * Check if a name matches an exclude pattern.
- * Supports simple glob: if pattern contains `*`, convert to regex.
- * Otherwise, exact match on the name.
+ * Pre-compile exclude patterns into a test function.
+ * Glob patterns (containing `*`) are compiled to RegExp once;
+ * plain strings use exact match.
  */
-function matchesExclude(name: string, patterns: string[]): boolean {
-  for (const pattern of patterns) {
+function buildExcludeMatcher(patterns: string[]): (name: string) => boolean {
+  const matchers: Array<(name: string) => boolean> = patterns.map((pattern) => {
     if (pattern.includes("*")) {
-      // Convert glob pattern to regex: escape dots, replace * with .*
       const regexStr = "^" + pattern.replace(/\./g, "\\.").replace(/\*/g, ".*") + "$";
-      if (new RegExp(regexStr).test(name)) return true;
-    } else {
-      if (name === pattern) return true;
+      const re = new RegExp(regexStr);
+      return (name: string) => re.test(name);
     }
-  }
-  return false;
+    return (name: string) => name === pattern;
+  });
+  return (name: string) => matchers.some((m) => m(name));
 }
 
 /**
  * Recursively collect files matching a pattern from a directory.
+ * Accepts a pre-compiled exclude matcher and extension Set to avoid
+ * repeated RegExp/array allocations during traversal.
  */
 async function collectFiles(
   dir: string,
   baseDir: string,
-  options: CollectOptions
+  options: CollectOptions,
+  isExcluded?: (name: string) => boolean,
+  extSet?: Set<string>
 ): Promise<ContextItem[]> {
+  const excludeFn = isExcluded ?? buildExcludeMatcher(options.exclude);
+  const extensions = extSet ?? new Set(options.extensions);
   const items: ContextItem[] = [];
   const entries = await readdir(dir, { withFileTypes: true });
 
@@ -55,27 +60,30 @@ async function collectFiles(
     const fullPath = join(dir, entry.name);
 
     // Resolve symlinks: isDirectory/isFile return false for symlinks
-    let isDir = entry.isDirectory();
-    let isFile = entry.isFile();
+    let isDir: boolean;
+    let isFile: boolean;
     if (entry.isSymbolicLink()) {
       const resolved = await stat(fullPath); // stat follows symlinks
       isDir = resolved.isDirectory();
       isFile = resolved.isFile();
+    } else {
+      isDir = entry.isDirectory();
+      isFile = entry.isFile();
     }
 
     if (isDir) {
       // Always skip hidden directories (starting with .)
       if (entry.name.startsWith(".")) continue;
       // Skip directories matching exclude patterns
-      if (matchesExclude(entry.name, options.exclude)) continue;
-      const subItems = await collectFiles(fullPath, baseDir, options);
+      if (excludeFn(entry.name)) continue;
+      const subItems = await collectFiles(fullPath, baseDir, options, excludeFn, extensions);
       items.push(...subItems);
     } else if (isFile) {
       // Skip files matching exclude patterns
-      if (matchesExclude(entry.name, options.exclude)) continue;
-      // Check if file matches any of the allowed extensions
-      const matchesExt = options.extensions.some((ext) => entry.name.endsWith(ext));
-      if (matchesExt) {
+      if (excludeFn(entry.name)) continue;
+      // Check if file matches any of the allowed extensions (O(1) Set lookup per extension suffix)
+      const dotIdx = entry.name.lastIndexOf(".");
+      if (dotIdx !== -1 && extensions.has(entry.name.slice(dotIdx))) {
         const content = await readFile(fullPath, "utf-8");
         items.push({
           path: relative(baseDir, fullPath),
@@ -100,8 +108,13 @@ function generateMetadata(ctx: LoadedContext): string {
 
   if (ctx.type === "list") {
     const items = ctx.content as ContextItem[];
-    const totalLength = items.reduce((sum, item) => sum + item.content.length, 0);
-    const chunkLengths = items.map((item) => item.content.length);
+    let totalLength = 0;
+    const chunkLengths: number[] = new Array(items.length);
+    for (let i = 0; i < items.length; i++) {
+      const len = items[i].content.length;
+      totalLength += len;
+      chunkLengths[i] = len;
+    }
 
     let chunkStr: string;
     if (chunkLengths.length > 100) {

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -206,30 +206,27 @@ export async function llmComplete(
   const cacheWriteTokens = response.usage?.cacheWrite ?? 0;
   const cost = (response.usage as any)?.cost?.total ?? 0;
 
-  const text = response.content
-    .filter((block: any) => block.type === "text")
-    .map((block: any) => block.text)
-    .join("");
-
-  // Count thought signatures in response for GROUP 2 verification
-  // These signatures enable multi-turn quality by circulating reasoning context
-  const thoughtSignatureCount = (response.content ?? []).reduce((count: number, block: any) => {
-    if (block.thinkingSignature || block.textSignature) count++;
-    return count;
-  }, 0);
-
-  // Extract code execution results from Gemini (GROUP 5)
-  // When codeExecution tool is enabled, Gemini returns executionResult blocks
+  // Single pass: extract text, count thought signatures, collect code execution results
+  const textParts: string[] = [];
+  let thoughtSignatureCount = 0;
   const codeExecutionResults: CodeExecutionResult[] = [];
   for (const block of response.content ?? []) {
-    if ((block as any).type === "executionResult") {
+    const b = block as any;
+    if (b.type === "text") {
+      textParts.push(b.text);
+    }
+    if (b.thinkingSignature || b.textSignature) {
+      thoughtSignatureCount++;
+    }
+    if (b.type === "executionResult") {
       codeExecutionResults.push({
-        code: (block as any).code ?? "",
-        outcome: (block as any).outcome ?? "OUTCOME_FAILED",
-        output: (block as any).output ?? "",
+        code: b.code ?? "",
+        outcome: b.outcome ?? "OUTCOME_FAILED",
+        output: b.output ?? "",
       });
     }
   }
+  const text = textParts.join("");
 
   // Emit to logger if provided
   if (options?.logger) {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7,6 +7,10 @@
 
 const MAX_FORMATTED_OUTPUT = 20_000;
 
+// Pre-compiled regexes for FINAL signal detection (used every RLM iteration)
+const FINAL_VAR_REGEX = /^\s*FINAL_VAR\((.*?)\)/m;
+const FINAL_REGEX = /^\s*FINAL\((.*)\)\s*$/m;
+
 /** A code block extracted from an LLM response. */
 export interface CodeBlock {
   code: string;
@@ -55,16 +59,14 @@ export function detectFinal(text: string, codeBlocks: CodeBlock[]): FinalSignal 
   const outsideText = getTextOutsideBlocks(text, codeBlocks);
 
   // Check FINAL_VAR first (higher priority)
-  const finalVarRegex = /^\s*FINAL_VAR\((.*?)\)/m;
-  const finalVarMatch = finalVarRegex.exec(outsideText);
+  const finalVarMatch = FINAL_VAR_REGEX.exec(outsideText);
   if (finalVarMatch) {
     const varName = finalVarMatch[1].trim().replace(/^["']|["']$/g, "");
     return { type: "final_var", value: varName };
   }
 
   // Check FINAL
-  const finalRegex = /^\s*FINAL\((.*)\)\s*$/m;
-  const finalMatch = finalRegex.exec(outsideText);
+  const finalMatch = FINAL_REGEX.exec(outsideText);
   if (finalMatch) {
     return { type: "final", value: finalMatch[1] };
   }

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -569,15 +569,13 @@ function buildResult(
 ): RLMResult {
   // Extract file references from the answer (paths like docs/foo/bar.md)
   const refRegex = /(?:^|[\s(["'])([a-zA-Z0-9_./-]+\.(?:md|txt|py|ts|js|json))/gm;
-  const references: string[] = [];
+  const refSet = new Set<string>();
   let match: RegExpExecArray | null;
 
   while ((match = refRegex.exec(answer)) !== null) {
-    const ref = match[1];
-    if (ref && !references.includes(ref)) {
-      references.push(ref);
-    }
+    if (match[1]) refSet.add(match[1]);
   }
+  const references = [...refSet];
 
   const result: RLMResult = {
     answer,


### PR DESCRIPTION
## Summary

Benchmarker sweep: targeted performance fixes for hot paths in the RLM iteration loop.

- **context.ts**: Pre-compile exclude `RegExp` patterns once via `buildExcludeMatcher()` instead of creating `new RegExp()` per file during recursive directory traversal. Use `Set<string>` for O(1) extension lookups instead of `Array.some()`. Avoid redundant `isDirectory()`/`isFile()` calls on non-symlink entries. Single-pass metadata generation (combined `reduce` + `map` into one loop).
- **parser.ts**: Hoist `FINAL_VAR_REGEX` and `FINAL_REGEX` to module-level constants — previously recreated on every `detectFinal()` call (once per RLM iteration).
- **llm.ts**: Combine 3 separate passes over `response.content` (text extraction, thought signature counting, code execution result collection) into a single loop.
- **rlm.ts**: Use `Set` for O(1) file reference deduplication in `buildResult()` instead of `Array.includes()`.

## Test plan

- [x] `npx tsc --noEmit` passes cleanly
- [x] `npx tsc` build succeeds
- [ ] Run existing benchmarks/tests to confirm no behavioral regression