### PR TITLE
refactor: simplify rlmLoop() and parseYamlConfig()

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -193,6 +193,17 @@ async function readOptionalFile(path: string): Promise<string | null> {
 }
 
 /**
+ * Validate a budget value is a positive number or null.
+ */
+function validatePositiveBudget(value: unknown, field: string): void {
+  if (value !== null && (typeof value !== "number" || value <= 0)) {
+    throw new Error(
+      `Invalid ${field}: must be a positive number or null, got ${value}.`
+    );
+  }
+}
+
+/**
  * Parse and validate an rlmx.yaml file.
  */
 function parseYamlConfig(content: string, dir: string): RlmxConfig {
@@ -260,21 +271,9 @@ function parseYamlConfig(content: string, dir: string): RlmxConfig {
   };
 
   // Validate budget values
-  if (budget.maxCost !== null && (typeof budget.maxCost !== "number" || budget.maxCost <= 0)) {
-    throw new Error(
-      `Invalid budget.max-cost: must be a positive number or null, got ${budget.maxCost}.`
-    );
-  }
-  if (budget.maxTokens !== null && (typeof budget.maxTokens !== "number" || budget.maxTokens <= 0)) {
-    throw new Error(
-      `Invalid budget.max-tokens: must be a positive number or null, got ${budget.maxTokens}.`
-    );
-  }
-  if (budget.maxDepth !== null && (typeof budget.maxDepth !== "number" || budget.maxDepth <= 0)) {
-    throw new Error(
-      `Invalid budget.max-depth: must be a positive number or null, got ${budget.maxDepth}.`
-    );
-  }
+  validatePositiveBudget(budget.maxCost, "budget.max-cost");
+  validatePositiveBudget(budget.maxTokens, "budget.max-tokens");
+  validatePositiveBudget(budget.maxDepth, "budget.max-depth");
 
   // Parse tools-level
   const rawLevel = cfg["tools-level"] ?? "core";

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -236,6 +236,13 @@ export async function rlmLoop(
       );
     });
 
+    /** Cleanup timeout/REPL and build the final result. */
+    const finalize = async (answer: string, iterations: number): Promise<RLMResult> => {
+      clearTimeout(timeoutHandle);
+      await repl.stop();
+      return buildResult(answer, usage, iterations, config, budget.getState().budgetHit, geminiCounts, repl.getGeminiBatteriesUsed());
+    };
+
     // Build initial message history
     const messages: ChatMessage[] = [
       { role: "system", content: systemPrompt },
@@ -295,37 +302,22 @@ export async function rlmLoop(
 
       // In structured output mode, treat the API response as the final answer (schema-enforced JSON)
       if (isStructuredOutputMode(config) && codeBlocks.length === 0) {
-        clearTimeout(timeoutHandle);
-        await repl.stop();
         if (opts.verbose) {
           logVerbose(iteration, "structured output mode: response is final answer");
         }
-        return buildResult(responseText, usage, iteration + 1, config, budget.getState().budgetHit, geminiCounts, repl.getGeminiBatteriesUsed());
+        return finalize(responseText, iteration + 1);
       }
 
       // Check for FINAL signal in the text (outside code blocks)
       const finalSignal = detectFinal(responseText, codeBlocks);
 
       if (finalSignal && codeBlocks.length === 0) {
-        // FINAL without code blocks — direct answer
-        clearTimeout(timeoutHandle);
-
         if (finalSignal.type === "final") {
-          await repl.stop();
-          return buildResult(finalSignal.value, usage, iteration + 1, config, budget.getState().budgetHit, geminiCounts, repl.getGeminiBatteriesUsed());
+          return finalize(finalSignal.value, iteration + 1);
         }
         // FINAL_VAR without code — get variable value before stopping REPL
         const varResult = await getVariableFromRepl(repl, finalSignal.value);
-        await repl.stop();
-        return buildResult(
-          varResult ?? finalSignal.value,
-          usage,
-          iteration + 1,
-          config,
-          budget.getState().budgetHit,
-          geminiCounts,
-          repl.getGeminiBatteriesUsed()
-        );
+        return finalize(varResult ?? finalSignal.value, iteration + 1);
       }
 
       // Execute code blocks in REPL
@@ -346,20 +338,8 @@ export async function rlmLoop(
           error: execResult.error,
         });
 
-        // Check if this execution produced a FINAL signal
         if (execResult.final) {
-          clearTimeout(timeoutHandle);
-          await repl.stop();
-
-          return buildResult(
-            execResult.final.value,
-            usage,
-            iteration + 1,
-            config,
-            budget.getState().budgetHit,
-            geminiCounts,
-            repl.getGeminiBatteriesUsed()
-          );
+          return finalize(execResult.final.value, iteration + 1);
         }
       }
 
@@ -383,49 +363,24 @@ export async function rlmLoop(
         }
       }
 
-      // Check for FINAL_VAR in text after code execution
-      if (finalSignal && finalSignal.type === "final_var") {
-        // The variable should now exist in the REPL after code execution
+      // Handle FINAL signal detected in text, after code execution
+      if (finalSignal) {
+        if (finalSignal.type === "final") {
+          return finalize(finalSignal.value, iteration + 1);
+        }
+        // FINAL_VAR — variable should now exist after code execution
         const varExec = await repl.execute(
           `__final_val = str(${finalSignal.value}) if '${finalSignal.value}' in dir() else "Variable '${finalSignal.value}' not found"`
         );
         if (varExec.final) {
-          clearTimeout(timeoutHandle);
-          await repl.stop();
-          return buildResult(
-            varExec.final.value,
-            usage,
-            iteration + 1,
-            config,
-            budget.getState().budgetHit,
-            geminiCounts,
-            repl.getGeminiBatteriesUsed()
-          );
+          return finalize(varExec.final.value, iteration + 1);
         }
-        // Try getting variable directly
         const getResult = await repl.execute(
           `FINAL_VAR("${finalSignal.value}")`
         );
         if (getResult.final) {
-          clearTimeout(timeoutHandle);
-          await repl.stop();
-          return buildResult(
-            getResult.final.value,
-            usage,
-            iteration + 1,
-            config,
-            budget.getState().budgetHit,
-            geminiCounts,
-            repl.getGeminiBatteriesUsed()
-          );
+          return finalize(getResult.final.value, iteration + 1);
         }
-      }
-
-      // Also check for FINAL in the text portion after code
-      if (finalSignal && finalSignal.type === "final") {
-        clearTimeout(timeoutHandle);
-        await repl.stop();
-        return buildResult(finalSignal.value, usage, iteration + 1, config, budget.getState().budgetHit, geminiCounts, repl.getGeminiBatteriesUsed());
       }
 
       // Format execution results and append to history
@@ -463,11 +418,6 @@ export async function rlmLoop(
         });
       }
 
-      // Update user prompt for next iteration
-      if (iteration + 1 < opts.maxIterations) {
-        // For iteration > 0, the user prompt is the continuation
-        // (already handled by the execution result above)
-      }
     }
 
     // Loop exited — force a final answer
@@ -477,18 +427,7 @@ export async function rlmLoop(
     }
 
     const forcedResult = await forceFinalAnswer(messages, config, usage, abortController.signal, cacheConfig);
-    clearTimeout(timeoutHandle);
-    await repl.stop();
-
-    return buildResult(
-      forcedResult,
-      usage,
-      actualIterations,
-      config,
-      budget.getState().budgetHit,
-      geminiCounts,
-      repl.getGeminiBatteriesUsed()
-    );
+    return finalize(forcedResult, actualIterations);
   } catch (err: any) {
     clearTimeout(timeoutHandle);
     await repl.stop().catch(() => {});


### PR DESCRIPTION
## Summary

- **Extract `finalize()` closure** in `rlmLoop()` to DRY up 8 repeated `clearTimeout + repl.stop + buildResult` patterns (−62 lines in rlm.ts)
- **Consolidate post-execution FINAL signal handling** — merged two separate `if (finalSignal)` blocks into one coherent block
- **Remove dead code** — empty `if` block with only comments (unused "update user prompt" branch)
- **Extract `validatePositiveBudget()`** in config.ts to DRY up 3 identical budget validation blocks

Net: **−62 lines** with zero behavior change. `tsc --noEmit` passes clean.

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [ ] Verify RLM loop behavior unchanged (FINAL, FINAL_VAR, structured output, timeout, budget termination paths)