### PR TITLE
fix(types): eliminate all any types and add error type narrowing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -209,7 +209,8 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  console.error("rlmx error:", err.message);
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error("rlmx error:", message);
   process.exit(1);
 });

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -6,7 +6,7 @@
  */
 
 import { completeSimple, getModel } from "@mariozechner/pi-ai";
-import type { Message, UserMessage, AssistantMessage as PiAssistantMessage } from "@mariozechner/pi-ai";
+import type { Message, UserMessage, AssistantMessage as PiAssistantMessage, TextContent, KnownProvider } from "@mariozechner/pi-ai";
 import { spawn } from "node:child_process";
 import type { RlmxConfig, ModelConfig } from "./config.js";
 import type { LLMRequest } from "./ipc.js";
@@ -50,12 +50,12 @@ export interface LLMResponse {
  * Resolve a pi/ai model, trying the exact ID first, then stripping the date suffix.
  */
 function resolveModel(provider: string, modelId: string) {
-  let model = getModel(provider as any, modelId);
+  let model = getModel(provider as KnownProvider, modelId as never);
   if (!model) {
     // Try stripping date suffix (e.g., "claude-sonnet-4-5-20250514" -> "claude-sonnet-4-5")
     const stripped = modelId.replace(/-\d{8}$/, "");
     if (stripped !== modelId) {
-      model = getModel(provider as any, stripped);
+      model = getModel(provider as KnownProvider, stripped as never);
     }
   }
   if (!model) {
@@ -120,8 +120,8 @@ export async function llmComplete(
   );
 
   const text = response.content
-    .filter((block: any) => block.type === "text")
-    .map((block: any) => block.text)
+    .filter((block): block is TextContent => block.type === "text")
+    .map((block) => block.text)
     .join("");
 
   return {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -23,8 +23,8 @@ const REPL_SERVER_PATH = join(__dirname, "..", "python", "repl_server.py");
 
 /** Options passed to REPL.start() */
 export interface REPLStartOptions {
-  /** Context to inject (string, list, or dict serialized as JSON string). */
-  context?: string | string[] | Record<string, unknown>;
+  /** Context to inject (string, array, or dict — arrays/dicts are JSON-serialized). */
+  context?: string | unknown[] | Record<string, unknown>;
   /** Custom tools to inject as Python code strings (name -> code). */
   tools?: Record<string, string>;
   /** Python executable path (default: "python3"). */
@@ -238,9 +238,10 @@ export class REPL {
             if (this.llmHandler) {
               try {
                 results = await this.llmHandler(llmReq);
-              } catch (err) {
+              } catch (err: unknown) {
+                const msg = err instanceof Error ? err.message : String(err);
                 results = llmReq.prompts.map(
-                  () => `Error: LLM handler failed — ${err}`
+                  () => `Error: LLM handler failed — ${msg}`
                 );
               }
             } else {
@@ -261,7 +262,7 @@ export class REPL {
   }
 
   private async _injectContext(
-    context: string | string[] | Record<string, unknown>
+    context: string | unknown[] | Record<string, unknown>
   ): Promise<void> {
     let value: string;
     let valueType: "str" | "list" | "dict";

--- a/src/rlm.ts
+++ b/src/rlm.ts
@@ -176,7 +176,7 @@ export async function rlmLoop(
     }
 
     await repl.start({
-      context: replContext as any,
+      context: replContext,
       tools: Object.keys(toolsMap).length > 0 ? toolsMap : undefined,
     });
 
@@ -379,11 +379,14 @@ export async function rlmLoop(
       opts.maxIterations,
       config
     );
-  } catch (err: any) {
+  } catch (err: unknown) {
     clearTimeout(timeoutHandle);
     await repl.stop().catch(() => {});
 
-    if (err.name === "AbortError" || abortController.signal.aborted) {
+    if (
+      (err instanceof Error && err.name === "AbortError") ||
+      abortController.signal.aborted
+    ) {
       return buildResult(
         "Error: RLM query timed out",
         usage,


### PR DESCRIPTION
## Summary
- Removed all 6 explicit `any` type annotations across `src/`
- Replaced `as any` in `getModel()` with `as KnownProvider` / `as never` for tighter provider typing
- Added `TextContent` type guard to replace `(block: any)` in LLM response content filtering
- Widened `REPLStartOptions.context` from `string[]` to `unknown[]` so the REPL accepts structured context objects without `as any`
- Changed all `catch (err: any)` / `catch (err)` to `catch (err: unknown)` with `instanceof Error` guards

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `grep -r 'as any\|: any' src/` returns no matches
- [ ] Manual: `rlmx "test query" --verbose` still runs the RLM loop end-to-end