### PR TITLE
release: promote dev → main (settings model override fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/rlmx",
-  "version": "0.260409.1",
+  "version": "0.260409.2",
   "description": "RLM algorithm CLI for coding agents — prompt externalization, Python REPL with symbolic recursion, code-driven navigation",
   "type": "module",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/rlmx",
-  "version": "0.260409.2",
+  "version": "0.260409.3",
   "description": "RLM algorithm CLI for coding agents — prompt externalization, Python REPL with symbolic recursion, code-driven navigation",
   "type": "module",
   "publishConfig": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,41 @@ import { createLogger } from "./logger.js";
 import { checkPythonVersion } from "./detect.js";
 import { estimateTokens, validateContextSize } from "./cache.js";
 import { runBatch } from "./batch.js";
-import { loadSettings, saveSettings, injectApiKeysToEnv, formatValue, parseSettingValue, getSettingsPath } from "./settings.js";
+import { loadSettings, saveSettings, injectApiKeysToEnv, formatValue, parseSettingValue, getSettingsPath, type GlobalSettings } from "./settings.js";
+import type { RlmxConfig } from "./config.js";
+
+/**
+ * Apply model overrides from global settings (~/.rlmx/settings.json).
+ * Priority: CLI flags > settings.json > rlmx.yaml > hardcoded defaults.
+ *
+ * This ensures `rlmx config set model.provider openai` actually takes effect
+ * even when a local rlmx.yaml exists with its own model defaults.
+ */
+/** Module-level ref so helper functions can apply overrides without re-loading. */
+let _globalSettings: GlobalSettings = {};
+
+/**
+ * Apply model overrides from global settings (~/.rlmx/settings.json).
+ * Priority: CLI flags > settings.json > rlmx.yaml > hardcoded defaults.
+ *
+ * This ensures `rlmx config set model.provider openai` actually takes effect
+ * even when a local rlmx.yaml exists with its own model defaults.
+ */
+function applySettingsModelOverrides(config: RlmxConfig, settings?: GlobalSettings): void {
+  const s = settings ?? _globalSettings;
+  const provider = s["model.provider"];
+  const model = s["model.model"];
+  const subCallModel = s["model.sub-call-model"];
+  if (typeof provider === "string" && provider) {
+    config.model.provider = provider;
+  }
+  if (typeof model === "string" && model) {
+    config.model.model = model;
+  }
+  if (typeof subCallModel === "string" && subCallModel) {
+    config.model.subCallModel = subCallModel;
+  }
+}
 
 const HELP = `rlmx — RLM algorithm CLI for coding agents
 
@@ -264,6 +298,7 @@ async function runQuery(opts: CliOptions): Promise<void> {
 
   // Load config
   const config = await loadConfig(configDir);
+  applySettingsModelOverrides(config);
 
   // Apply CLI overrides to config
   if (opts.thinking) {
@@ -460,6 +495,7 @@ async function runCache(opts: CliOptions): Promise<void> {
   // Load config
   const configDir = process.cwd();
   const config = await loadConfig(configDir);
+  applySettingsModelOverrides(config);
 
   // Apply CLI overrides
   if (opts.tools) {
@@ -544,6 +580,7 @@ async function runBatchCommand(opts: CliOptions): Promise<void> {
 
   // Load config
   const config = await loadConfig(configDir);
+  applySettingsModelOverrides(config);
 
   // Apply CLI overrides to config
   config.cache.enabled = true; // batch always uses cache
@@ -708,6 +745,7 @@ async function runBenchmarkCommand(opts: CliOptions, args: string[]): Promise<vo
   const mode = args[0];
   const configDir = process.cwd();
   const config = await loadConfig(configDir);
+  applySettingsModelOverrides(config);
 
   if (opts.tools) config.toolsLevel = opts.tools;
 
@@ -744,6 +782,7 @@ async function main(): Promise<void> {
 
   // Load global settings and inject API keys before any command
   const globalSettings = await loadSettings();
+  _globalSettings = globalSettings;
   injectApiKeysToEnv(globalSettings);
 
   switch (opts.command) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.260409.2';
+export const VERSION = '0.260409.3';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.260409.1';
+export const VERSION = '0.260409.2';


### PR DESCRIPTION
## Summary
- Settings model override fix: `rlmx config set model.provider` now actually takes effect over rlmx.yaml defaults
- Includes pi-ai 0.66.1 bump for OpenAI gpt-5.x support

## Test plan
- [x] `tsc --noEmit` clean
- [x] CLI verified end-to-end with `openai/gpt-5.4-mini` via settings override
- [x] All CI checks green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global model settings now take precedence over project-specific configurations in query, cache, batch, and benchmark operations, enabling streamlined cross-project model management.

* **Chores**
  * Version updated to 0.260409.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->