### PR TITLE
chore: bump pgserve to ^1.1.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@mariozechner/pi-ai": "0.66.1",
         "js-yaml": "^4.1.1",
         "pg": "^8.20.0",
-        "pgserve": "^1.1.6",
+        "pgserve": "^1.1.8",
       },
       "devDependencies": {
         "@commitlint/cli": "^19.0.0",
@@ -522,7 +522,7 @@
 
     "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
 
-    "pgserve": ["pgserve@1.1.6", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": "bin/pgserve-wrapper.cjs" }, "sha512-qdgiU3q/o/k8lP+IPHLiZG5uTWmvCSgqM3erdP7nmgVeQYv89DTo0nSG5XB0ccVD7yG/BppLFHjRvvXcWVgKnQ=="],
+    "pgserve": ["pgserve@1.1.8", "", { "dependencies": { "bun": "^1.3.4" }, "optionalDependencies": { "@embedded-postgres/darwin-arm64": "18.2.0-beta.16", "@embedded-postgres/darwin-x64": "18.2.0-beta.16", "@embedded-postgres/linux-x64": "18.2.0-beta.16", "@embedded-postgres/windows-x64": "18.2.0-beta.16" }, "bin": { "pgserve": "bin/pgserve-wrapper.cjs" } }, "sha512-CZJK6uWqua50Bz/l4T9hubGWdWfycJfWN0UptnhMhvGVmdKBOC9qQTleBr4HaF6ESTaHBBfq/WuWpKfscGhxNA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mariozechner/pi-ai": "0.66.1",
     "js-yaml": "^4.1.1",
     "pg": "^8.20.0",
-    "pgserve": "^1.1.6"
+    "pgserve": "^1.1.8"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",


### PR DESCRIPTION
## Summary

Bumps `pgserve` from `^1.1.6` to `^1.1.8` to pick up the pgvector auto-install regex fix from [namastexlabs/pgserve#20](https://github.com/namastexlabs/pgserve/pull/20).

## Why this matters

On PG 14+, previous pgserve versions silently fell back to a hardcoded `'17'` PG major when parsing `postgres --version` output (`postgres (PostgreSQL) 18.2`). The old regex `/PostgreSQL (\d+)/` expected a digit immediately after `PostgreSQL ` and failed to match past the closing `)`, so the fallback kicked in and downloaded `postgresql-17-pgvector.deb` into a PG18 lib dir.

Everything looked fine until `CREATE EXTENSION vector`, which died with:

```
ERROR: incompatible library version: server is version 18, library is version 17
```

1.1.8 fixes the regex to `/PostgreSQL\)?\s+(\d+)/`, throws loudly on unparseable output instead of silently defaulting, and logs the detected major at info level.

## Heads up: existing stale installs

This bump alone **does not heal deployments that already have a broken `vector.so` on disk** — those stay broken until someone manually wipes `~/.pgserve/bin/linux-x64/lib/vector.so` or the auto-heal feature from [namastexlabs/pgserve#21](https://github.com/namastexlabs/pgserve/pull/21) lands as `1.1.9`.

If you hit "incompatible library version" after this merge, run:

```bash
rm ~/.pgserve/bin/linux-x64/lib/vector.so
rm -f ~/.pgserve/bin/linux-x64/share/postgresql/extension/vector*
```

…and restart. The corrected 1.1.8 code will re-download the right `.deb` on next `CREATE EXTENSION`.

## Changes

- `package.json`: `pgserve ^1.1.6` → `^1.1.8`
- `bun.lock`: refreshed pgserve entry (sha512 + version string)

## Test plan

- [ ] CI passes
- [ ] Local smoke test: start the embedded PG + create a pgvector-enabled database


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->