### PR TITLE
fix: sync package-lock.json with pgserve ^1.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@automagik/rlmx",
-  "version": "0.260331.5",
+  "version": "0.260409.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automagik/rlmx",
-      "version": "0.260331.5",
+      "version": "0.260409.3",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-ai": "0.66.1",
         "js-yaml": "^4.1.1",
         "pg": "^8.20.0",
-        "pgserve": "^1.1.6"
+        "pgserve": "^1.1.8"
       },
       "bin": {
         "rlmx": "dist/src/cli.js"
@@ -3525,9 +3525,9 @@
       }
     },
     "node_modules/pgserve": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/pgserve/-/pgserve-1.1.6.tgz",
-      "integrity": "sha512-qdgiU3q/o/k8lP+IPHLiZG5uTWmvCSgqM3erdP7nmgVeQYv89DTo0nSG5XB0ccVD7yG/BppLFHjRvvXcWVgKnQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/pgserve/-/pgserve-1.1.9.tgz",
+      "integrity": "sha512-VOstbMjgy3H5j9n0cZg+4M8bTnfRyHxTUi3qNNOEVnzBRhw3l/L0RWwnXlb7tQe9CLZ2pSy8hAmNj1FgaHg0gg==",
       "license": "MIT",
       "dependencies": {
         "bun": "^1.3.4"


### PR DESCRIPTION
## Root Cause

Commit 6c7105f bumped pgserve in package.json from `^1.1.6` to `^1.1.8` and updated `bun.lock`, but did NOT update `package-lock.json`. The lockfile still resolved pgserve to `1.1.6`, which fails `npm ci` validation in the release workflow.

## Fix

Regenerated `package-lock.json` via `npm install` to resolve pgserve to `1.1.9` (latest version satisfying `^1.1.8`).

## Affected

- Release workflow (`npm ci` step) -- currently broken on main
- Two orphaned releases (v0.260410.1, v0.260412.1) exist without npm packages

## Verification

- `npm ci` succeeds locally after this change
- All 192 tests pass (zero failures)
- Only `package-lock.json` changed (6 insertions, 6 deletions)