### PR TITLE
feat(sdk): Event SDK skeleton — Wish B Group 1

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,66 @@
+# rlmx SDK — Event Stream
+
+> **Status:** Wish B Group 1 skeleton — event types + emitter only.
+> `runAgent()` / `resumeAgent()` / permission hooks land in Groups 2–3.
+> See `.genie/wishes/rlmx-sdk-upgrade/WISH.md`.
+
+The SDK yields a stream of typed events describing one agent run.
+Consumers drive the stream with `for await`; the SDK core pushes
+events at every state transition.
+
+```ts
+import { sdk } from "@automagik/rlmx";
+// Future (Group 2): const stream = sdk.runAgent({ ... });
+// Today: construct an emitter manually for tests / preview.
+const em = sdk.createEmitter();
+
+em.emit(
+	sdk.makeEvent("AgentStart", {
+		agentId: "demo",
+		sessionId: "s-1",
+		config: { model: "claude-sonnet-4-6" },
+	}),
+);
+
+for await (const ev of em) {
+	console.log(ev.type, ev.timestamp);
+}
+```
+
+## Event catalogue (10 types)
+
+| `type`            | Emitted when                                          |
+| ----------------- | ----------------------------------------------------- |
+| `AgentStart`      | Once per `runAgent()` before the first iteration.     |
+| `IterationStart`  | At the top of each REPL iteration.                    |
+| `IterationOutput` | After an iteration completes, with its output string. |
+| `ToolCallBefore`  | Immediately before a tool invocation.                 |
+| `ToolCallAfter`   | Immediately after a tool returns (success or error).  |
+| `Recurse`         | On every `rlm_query` recursion, with depth metadata.  |
+| `Validation`      | After an `emit_done` payload is schema-checked.       |
+| `Message`         | For human-readable system / user / assistant turns.   |
+| `EmitDone`        | When the agent signals completion with a payload.     |
+| `Error`           | For non-fatal + fatal failures, tagged by phase.      |
+
+Every event carries a `timestamp` (`ISO-8601` UTC) and a discriminant
+`type` field. Round-trip through JSON is lossless — `isAgentEvent()`
+recognises the deserialised shape.
+
+## Emitter contract
+
+- `emit(event)` — synchronous push. Silently no-ops after `close()`.
+- `close()` — idempotent; terminates all pending iterator pulls with `{ done: true }`.
+- `subscribe()` — returns a fresh `AsyncIterableIterator`. Multiple
+  subscribers receive fan-out copies of every post-subscribe event.
+- Pre-subscribe events are buffered and replay to the **first**
+  subscriber only (no double-delivery).
+- The emitter itself is directly iterable via `for await (const ev of em)`.
+
+## Scope boundary
+
+This PR ships the contract shape + emit infrastructure. It does **not**:
+
+- instrument `rlm.ts` with emit calls (Group 2–3);
+- define `runAgent()` / `resumeAgent()` (Group 2);
+- wire permission hooks or the `VALIDATE.md` primitive (Group 2);
+- touch CLI behaviour — `rlmx "query"` is unchanged.

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,3 +54,8 @@ export type { RLMResult, StreamEvent, StatsData, GeminiStatsData, CacheStats } f
 
 export { Logger, createLogger } from "./logger.js";
 export type { EventType, LogEvent } from "./logger.js";
+
+// ─── SDK (Wish B Group 1 skeleton) ─────────────────────────────────
+// Event types + emitter only. `runAgent()` / `resumeAgent()` /
+// permission hooks land in Groups 2-3 per `.genie/wishes/rlmx-sdk-upgrade`.
+export * as sdk from "./sdk/index.js";

--- a/src/sdk/emitter.ts
+++ b/src/sdk/emitter.ts
@@ -1,0 +1,162 @@
+/**
+ * Event emitter with async-iterator contract — Wish B Group 1 skeleton.
+ *
+ * The SDK's async iterator yields `AgentEvent`s as the agent runs. The
+ * emitter is a thin broker: producers call `emit()` at state boundaries;
+ * consumers iterate via `for await`. Multiple consumers may subscribe
+ * to the same emitter — each receives every event.
+ *
+ * This file ships the contract shape only. Hooking the emitter into
+ * `rlm.ts` + exposing `runAgent()` lands in Group 2-3 per WISH.md.
+ */
+
+import type { AgentEvent } from "./events.js";
+
+/**
+ * Producer API — what the SDK core calls.
+ *
+ * `emit` is synchronous: events land in an in-memory queue and are
+ * delivered to subscribers via the async iterator. `close` signals
+ * that no more events will arrive; consumers' iterators return.
+ */
+export interface EventEmitter {
+	emit(event: AgentEvent): void;
+	close(): void;
+	/** Idempotent. `true` after the first `close()` call. */
+	readonly closed: boolean;
+}
+
+/**
+ * Consumer API — what `runAgent()` hands back to SDK users.
+ * The emitter itself IS the iterable; users can also call `subscribe()`
+ * for a fresh iterator (useful when wiring multiple consumers to one
+ * run).
+ */
+export interface EventStream extends AsyncIterable<AgentEvent> {
+	subscribe(): AsyncIterableIterator<AgentEvent>;
+}
+
+/** Combined interface — the default implementation satisfies both. */
+export type EmitterAndStream = EventEmitter & EventStream;
+
+/**
+ * Create an emitter with an async-iterator backplane. Broadcasts to
+ * every subscriber; each subscriber sees events in emit order. Buffers
+ * events that arrive before any subscriber is attached so no early
+ * emissions are lost.
+ *
+ * The buffer is unbounded by default — for Group 1 the expected
+ * volume is ~10³ events per run. If back-pressure becomes an issue we
+ * revisit (Group 3 per-depth metrics may push volume higher).
+ */
+export function createEmitter(): EmitterAndStream {
+	type PendingPull = {
+		resolve(result: IteratorResult<AgentEvent>): void;
+	};
+
+	const subscribers: {
+		pending: PendingPull[];
+		buffer: AgentEvent[];
+		done: boolean;
+	}[] = [];
+
+	let closed = false;
+	/** Shared pre-subscribe backlog — forwarded to the first subscriber. */
+	const preBuffer: AgentEvent[] = [];
+
+	function flushTo(
+		sub: (typeof subscribers)[number],
+		events: readonly AgentEvent[],
+	): void {
+		for (const ev of events) {
+			const pull = sub.pending.shift();
+			if (pull) pull.resolve({ value: ev, done: false });
+			else sub.buffer.push(ev);
+		}
+	}
+
+	function completeSub(sub: (typeof subscribers)[number]): void {
+		if (sub.done) return;
+		sub.done = true;
+		while (sub.pending.length > 0) {
+			const pull = sub.pending.shift();
+			pull?.resolve({ value: undefined, done: true });
+		}
+	}
+
+	function emit(event: AgentEvent): void {
+		if (closed) return; // Silently drop post-close emissions.
+		if (subscribers.length === 0) {
+			preBuffer.push(event);
+			return;
+		}
+		for (const sub of subscribers) {
+			if (!sub.done) flushTo(sub, [event]);
+		}
+	}
+
+	function close(): void {
+		if (closed) return;
+		closed = true;
+		for (const sub of subscribers) completeSub(sub);
+	}
+
+	function subscribe(): AsyncIterableIterator<AgentEvent> {
+		const sub: (typeof subscribers)[number] = {
+			pending: [],
+			buffer: [],
+			done: false,
+		};
+		subscribers.push(sub);
+		// Deliver any pre-subscribe backlog so late subscribers still
+		// receive the run's opening events. Only the FIRST subscriber
+		// drains the preBuffer to avoid re-broadcasting.
+		if (subscribers.length === 1 && preBuffer.length > 0) {
+			flushTo(sub, preBuffer);
+			preBuffer.length = 0;
+		}
+		if (closed) completeSub(sub);
+
+		const iter: AsyncIterableIterator<AgentEvent> = {
+			next(): Promise<IteratorResult<AgentEvent>> {
+				if (sub.buffer.length > 0) {
+					const value = sub.buffer.shift() as AgentEvent;
+					return Promise.resolve({ value, done: false });
+				}
+				if (sub.done) {
+					return Promise.resolve({
+						value: undefined,
+						done: true,
+					});
+				}
+				return new Promise<IteratorResult<AgentEvent>>((resolve) => {
+					sub.pending.push({ resolve });
+				});
+			},
+			return(): Promise<IteratorResult<AgentEvent>> {
+				completeSub(sub);
+				return Promise.resolve({ value: undefined, done: true });
+			},
+			throw(err?: unknown): Promise<IteratorResult<AgentEvent>> {
+				completeSub(sub);
+				return Promise.reject(err);
+			},
+			[Symbol.asyncIterator]() {
+				return this;
+			},
+		};
+		return iter;
+	}
+
+	return {
+		emit,
+		close,
+		get closed() {
+			return closed;
+		},
+		subscribe,
+		[Symbol.asyncIterator](): AsyncIterableIterator<AgentEvent> {
+			return subscribe();
+		},
+	};
+}

--- a/src/sdk/events.ts
+++ b/src/sdk/events.ts
@@ -1,0 +1,190 @@
+/**
+ * SDK event types — Wish B Group 1 skeleton (issue rlmx-sdk-upgrade).
+ *
+ * These 10 events are the contract the SDK exposes to consumers of
+ * `runAgent()`. They are yielded in order by an async iterator (see
+ * `emitter.ts`) and together form a complete narrative of one agent
+ * run: configuration → iteration loop → tool use → recursion →
+ * validation → emit_done → error/success.
+ *
+ * Group 1 defines types and emit infrastructure only. Instrumentation
+ * hooks inside `rlm.ts`, the `runAgent()` entry point, and consumer
+ * wiring (session, permissions, validate) land in Groups 2-3.
+ *
+ * Spec source: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L21.
+ */
+export type AgentEventType =
+	| "AgentStart"
+	| "IterationStart"
+	| "IterationOutput"
+	| "ToolCallBefore"
+	| "ToolCallAfter"
+	| "Recurse"
+	| "Validation"
+	| "Message"
+	| "EmitDone"
+	| "Error";
+
+/** Base shape — every event carries a timestamp + discriminant. */
+interface BaseEvent {
+	/** ISO-8601 timestamp emitted by `iso()`. */
+	readonly timestamp: string;
+}
+
+/** Fired once per `runAgent()` before the first iteration. */
+export interface AgentStartEvent extends BaseEvent {
+	readonly type: "AgentStart";
+	readonly agentId: string;
+	readonly sessionId: string;
+	/** Opaque snapshot of the config the SDK resolved at spawn time. */
+	readonly config: Readonly<Record<string, unknown>>;
+}
+
+export interface IterationStartEvent extends BaseEvent {
+	readonly type: "IterationStart";
+	readonly sessionId: string;
+	readonly iteration: number;
+}
+
+export interface IterationOutputEvent extends BaseEvent {
+	readonly type: "IterationOutput";
+	readonly sessionId: string;
+	readonly iteration: number;
+	readonly output: string;
+}
+
+export interface ToolCallBeforeEvent extends BaseEvent {
+	readonly type: "ToolCallBefore";
+	readonly sessionId: string;
+	readonly iteration: number;
+	readonly tool: string;
+	readonly args: unknown;
+}
+
+export interface ToolCallAfterEvent extends BaseEvent {
+	readonly type: "ToolCallAfter";
+	readonly sessionId: string;
+	readonly iteration: number;
+	readonly tool: string;
+	readonly result: unknown;
+	readonly durationMs: number;
+	readonly ok: boolean;
+}
+
+/** Emitted each time the agent recurses via `rlm_query`. */
+export interface RecurseEvent extends BaseEvent {
+	readonly type: "Recurse";
+	readonly sessionId: string;
+	readonly iteration: number;
+	readonly depth: number;
+	readonly parentDepth: number;
+	readonly query: string;
+}
+
+/**
+ * Validation outcome after an `emit_done` payload. `status: "pass"` ends
+ * the loop; `status: "fail"` with `attempt: 1` triggers a retry with
+ * the schema hint prepended. `attempt: 2` with `"fail"` is terminal
+ * and forwarded as a ValidationFailedEvent via the caller.
+ */
+export interface ValidationEvent extends BaseEvent {
+	readonly type: "Validation";
+	readonly sessionId: string;
+	readonly status: "pass" | "fail";
+	readonly attempt: number;
+	readonly errors?: readonly string[];
+}
+
+export interface MessageEvent extends BaseEvent {
+	readonly type: "Message";
+	readonly sessionId: string;
+	readonly role: "system" | "user" | "assistant";
+	readonly content: string;
+}
+
+export interface EmitDoneEvent extends BaseEvent {
+	readonly type: "EmitDone";
+	readonly sessionId: string;
+	readonly payload: unknown;
+}
+
+export interface ErrorEvent extends BaseEvent {
+	readonly type: "Error";
+	readonly sessionId: string;
+	/**
+	 * Phase marker — lets consumers attribute the error to a specific
+	 * pipeline stage (`"spawn" | "iteration" | "tool" | "validate" | ...`).
+	 * Free-form string; consumers should not switch on unknown values.
+	 */
+	readonly phase: string;
+	readonly error: {
+		readonly name: string;
+		readonly message: string;
+		readonly stack?: string;
+	};
+}
+
+/** Discriminated union — the sole surface SDK consumers iterate over. */
+export type AgentEvent =
+	| AgentStartEvent
+	| IterationStartEvent
+	| IterationOutputEvent
+	| ToolCallBeforeEvent
+	| ToolCallAfterEvent
+	| RecurseEvent
+	| ValidationEvent
+	| MessageEvent
+	| EmitDoneEvent
+	| ErrorEvent;
+
+/**
+ * Exhaustive sentinel — useful for switch statements so TS flags any
+ * consumer that forgets to handle a new variant as the union grows.
+ */
+export const ALL_AGENT_EVENT_TYPES: readonly AgentEventType[] = [
+	"AgentStart",
+	"IterationStart",
+	"IterationOutput",
+	"ToolCallBefore",
+	"ToolCallAfter",
+	"Recurse",
+	"Validation",
+	"Message",
+	"EmitDone",
+	"Error",
+] as const;
+
+/** ISO-8601 in UTC — identical across machines + easy for downstream parsing. */
+export function iso(now: Date = new Date()): string {
+	return now.toISOString();
+}
+
+/**
+ * Build an event from a partial — the SDK internals call this instead
+ * of writing object literals, so the timestamp + discriminant land
+ * consistently and future additions (e.g. `spanId`) can be filled in
+ * here without touching every call site.
+ */
+export function makeEvent<E extends AgentEvent>(
+	type: E["type"],
+	fields: Omit<E, "type" | "timestamp"> & { timestamp?: string },
+): E {
+	const { timestamp, ...rest } = fields as Omit<E, "type" | "timestamp"> & {
+		timestamp?: string;
+	};
+	return { ...(rest as object), type, timestamp: timestamp ?? iso() } as E;
+}
+
+/**
+ * Round-trip hardness check — used in tests. Every event must
+ * serialize to JSON without losing its discriminant or timestamp.
+ */
+export function isAgentEvent(value: unknown): value is AgentEvent {
+	if (!value || typeof value !== "object") return false;
+	const v = value as Record<string, unknown>;
+	return (
+		typeof v.type === "string" &&
+		typeof v.timestamp === "string" &&
+		(ALL_AGENT_EVENT_TYPES as readonly string[]).includes(v.type as string)
+	);
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,0 +1,35 @@
+/**
+ * SDK public surface — Wish B Group 1 skeleton.
+ *
+ * Group 1 ships event types + emitter. `runAgent()`, `resumeAgent()`,
+ * permission hooks, and validate primitives are defined by Groups 2-3
+ * per `.genie/wishes/rlmx-sdk-upgrade/WISH.md`. The public re-export
+ * stays intentionally narrow — consumers depending on internals would
+ * break when Group 2 lands.
+ */
+export {
+	ALL_AGENT_EVENT_TYPES,
+	isAgentEvent,
+	iso,
+	makeEvent,
+} from "./events.js";
+export type {
+	AgentEvent,
+	AgentEventType,
+	AgentStartEvent,
+	EmitDoneEvent,
+	ErrorEvent,
+	IterationOutputEvent,
+	IterationStartEvent,
+	MessageEvent,
+	RecurseEvent,
+	ToolCallAfterEvent,
+	ToolCallBeforeEvent,
+	ValidationEvent,
+} from "./events.js";
+export { createEmitter } from "./emitter.js";
+export type {
+	EmitterAndStream,
+	EventEmitter,
+	EventStream,
+} from "./emitter.js";

--- a/tests/sdk-emitter.test.ts
+++ b/tests/sdk-emitter.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	type AgentEvent,
+	createEmitter,
+	makeEvent,
+} from "../src/sdk/index.js";
+
+function iterStart(sessionId: string, iteration: number): AgentEvent {
+	return makeEvent<AgentEvent>("IterationStart", {
+		sessionId,
+		iteration,
+	} as never);
+}
+
+async function collect(
+	iter: AsyncIterableIterator<AgentEvent>,
+	count: number,
+): Promise<AgentEvent[]> {
+	const out: AgentEvent[] = [];
+	for (let i = 0; i < count; i++) {
+		const { value, done } = await iter.next();
+		if (done) break;
+		out.push(value);
+	}
+	return out;
+}
+
+describe("SDK emitter — async-iterator contract (Wish B Group 1)", () => {
+	it("delivers emitted events to a subscriber in order", async () => {
+		const em = createEmitter();
+		const sub = em.subscribe();
+		em.emit(iterStart("s1", 1));
+		em.emit(iterStart("s1", 2));
+		em.emit(iterStart("s1", 3));
+		const got = await collect(sub, 3);
+		assert.equal(got.length, 3);
+		assert.equal((got[0] as { iteration: number }).iteration, 1);
+		assert.equal((got[2] as { iteration: number }).iteration, 3);
+	});
+
+	it("buffers events emitted before the first subscribe()", async () => {
+		const em = createEmitter();
+		em.emit(iterStart("s1", 1));
+		em.emit(iterStart("s1", 2));
+		const sub = em.subscribe();
+		const got = await collect(sub, 2);
+		assert.equal(got.length, 2);
+	});
+
+	it("pre-subscribe buffer only replays to the first subscriber (no double-deliver)", async () => {
+		const em = createEmitter();
+		em.emit(iterStart("s1", 1));
+		const first = em.subscribe();
+		const firstEvents = await collect(first, 1);
+		assert.equal(firstEvents.length, 1);
+		// Second subscriber should NOT receive the pre-subscribe event.
+		const second = em.subscribe();
+		em.emit(iterStart("s1", 2));
+		const secondEvents = await collect(second, 1);
+		assert.equal(secondEvents.length, 1);
+		assert.equal((secondEvents[0] as { iteration: number }).iteration, 2);
+	});
+
+	it("fan-outs post-subscribe events to every active subscriber", async () => {
+		const em = createEmitter();
+		const a = em.subscribe();
+		const b = em.subscribe();
+		em.emit(iterStart("s1", 7));
+		const [ea] = await collect(a, 1);
+		const [eb] = await collect(b, 1);
+		assert.ok(ea && eb);
+		assert.equal((ea as { iteration: number }).iteration, 7);
+		assert.equal((eb as { iteration: number }).iteration, 7);
+	});
+
+	it("close() terminates pending iterator pulls with done:true", async () => {
+		const em = createEmitter();
+		const sub = em.subscribe();
+		const pending = sub.next();
+		em.close();
+		const result = await pending;
+		assert.equal(result.done, true);
+		assert.equal(em.closed, true);
+	});
+
+	it("close() is idempotent + post-close emits are dropped silently", async () => {
+		const em = createEmitter();
+		em.close();
+		em.close(); // second close must not throw
+		em.emit(iterStart("s1", 1)); // dropped
+		const sub = em.subscribe();
+		const { done } = await sub.next();
+		assert.equal(done, true);
+	});
+
+	it("await-then-emit flow works (pull before push)", async () => {
+		const em = createEmitter();
+		const sub = em.subscribe();
+		const pull = sub.next();
+		// Emit after subscriber has called .next() — the pending promise
+		// must resolve with the event.
+		queueMicrotask(() => em.emit(iterStart("s1", 99)));
+		const res = await pull;
+		assert.equal(res.done, false);
+		assert.equal((res.value as { iteration: number }).iteration, 99);
+	});
+
+	it("is directly iterable via `for await`", async () => {
+		const em = createEmitter();
+		em.emit(iterStart("s1", 1));
+		em.emit(iterStart("s1", 2));
+		em.close();
+		const collected: AgentEvent[] = [];
+		for await (const ev of em) {
+			collected.push(ev);
+		}
+		assert.equal(collected.length, 2);
+	});
+
+	it("iterator.return() cleanly exits the subscriber", async () => {
+		const em = createEmitter();
+		const sub = em.subscribe();
+		em.emit(iterStart("s1", 1));
+		const first = await sub.next();
+		assert.equal(first.done, false);
+		// Simulate early break from `for await` — the runtime calls return().
+		const retRes = await (sub.return ? sub.return() : Promise.resolve({
+			value: undefined,
+			done: true,
+		}));
+		assert.equal(retRes.done, true);
+		// Next pull after return() should also yield done:true.
+		const after = await sub.next();
+		assert.equal(after.done, true);
+	});
+});

--- a/tests/sdk-events.test.ts
+++ b/tests/sdk-events.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	ALL_AGENT_EVENT_TYPES,
+	type AgentEvent,
+	type AgentEventType,
+	isAgentEvent,
+	iso,
+	makeEvent,
+} from "../src/sdk/index.js";
+
+describe("SDK events — the 10-event contract (Wish B Group 1)", () => {
+	it("exports exactly 10 event type names matching WISH.md", () => {
+		const expected: readonly AgentEventType[] = [
+			"AgentStart",
+			"IterationStart",
+			"IterationOutput",
+			"ToolCallBefore",
+			"ToolCallAfter",
+			"Recurse",
+			"Validation",
+			"Message",
+			"EmitDone",
+			"Error",
+		];
+		assert.deepEqual(
+			[...ALL_AGENT_EVENT_TYPES],
+			[...expected],
+			"ALL_AGENT_EVENT_TYPES must match wish spec exactly",
+		);
+		assert.equal(ALL_AGENT_EVENT_TYPES.length, 10);
+	});
+
+	it("makeEvent fills timestamp + type automatically", () => {
+		const ev = makeEvent<AgentEvent>("IterationStart", {
+			sessionId: "s1",
+			iteration: 3,
+		} as Omit<AgentEvent, "type" | "timestamp">);
+		assert.equal(ev.type, "IterationStart");
+		assert.ok(ev.timestamp);
+		assert.doesNotThrow(() => new Date(ev.timestamp));
+	});
+
+	it("makeEvent preserves caller-supplied timestamp", () => {
+		const stamp = "2026-04-22T10:00:00.000Z";
+		const ev = makeEvent<AgentEvent>("AgentStart", {
+			agentId: "a1",
+			sessionId: "s1",
+			config: { model: "claude-sonnet-4-6" },
+			timestamp: stamp,
+		} as Omit<AgentEvent, "type"> & { timestamp?: string });
+		assert.equal(ev.timestamp, stamp);
+	});
+
+	it("every event type is JSON-round-trippable with its discriminant intact", () => {
+		const samples: AgentEvent[] = [
+			makeEvent<AgentEvent>("AgentStart", {
+				agentId: "a1",
+				sessionId: "s1",
+				config: {},
+			} as never),
+			makeEvent<AgentEvent>("IterationStart", {
+				sessionId: "s1",
+				iteration: 1,
+			} as never),
+			makeEvent<AgentEvent>("IterationOutput", {
+				sessionId: "s1",
+				iteration: 1,
+				output: "hello",
+			} as never),
+			makeEvent<AgentEvent>("ToolCallBefore", {
+				sessionId: "s1",
+				iteration: 1,
+				tool: "search",
+				args: { q: "x" },
+			} as never),
+			makeEvent<AgentEvent>("ToolCallAfter", {
+				sessionId: "s1",
+				iteration: 1,
+				tool: "search",
+				result: { hits: 3 },
+				durationMs: 42,
+				ok: true,
+			} as never),
+			makeEvent<AgentEvent>("Recurse", {
+				sessionId: "s1",
+				iteration: 1,
+				depth: 2,
+				parentDepth: 1,
+				query: "nested",
+			} as never),
+			makeEvent<AgentEvent>("Validation", {
+				sessionId: "s1",
+				status: "pass",
+				attempt: 1,
+			} as never),
+			makeEvent<AgentEvent>("Message", {
+				sessionId: "s1",
+				role: "assistant",
+				content: "ok",
+			} as never),
+			makeEvent<AgentEvent>("EmitDone", {
+				sessionId: "s1",
+				payload: { answer: 42 },
+			} as never),
+			makeEvent<AgentEvent>("Error", {
+				sessionId: "s1",
+				phase: "tool",
+				error: { name: "Error", message: "boom" },
+			} as never),
+		];
+
+		assert.equal(samples.length, 10);
+		for (const ev of samples) {
+			const round = JSON.parse(JSON.stringify(ev));
+			assert.equal(round.type, ev.type);
+			assert.equal(round.timestamp, ev.timestamp);
+			assert.ok(
+				isAgentEvent(round),
+				`${ev.type}: round-trip failed isAgentEvent check`,
+			);
+		}
+	});
+
+	it("isAgentEvent rejects non-events", () => {
+		assert.equal(isAgentEvent(null), false);
+		assert.equal(isAgentEvent(undefined), false);
+		assert.equal(isAgentEvent({}), false);
+		assert.equal(isAgentEvent({ type: "NotAnEvent", timestamp: iso() }), false);
+		assert.equal(isAgentEvent({ type: "AgentStart" }), false); // missing timestamp
+		assert.equal(isAgentEvent("AgentStart"), false);
+	});
+
+	it("iso() returns a valid ISO-8601 timestamp in UTC", () => {
+		const s = iso();
+		// Strict ISO-8601 with trailing Z (UTC); accept ms precision.
+		assert.match(s, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+	});
+});


### PR DESCRIPTION
## Summary

First slice of the rlmx SDK upgrade. Defines the **10-event contract** that `runAgent()` will yield in later groups, plus the async-iterator **emitter** that brokers events between producers and consumers. Zero behavioural change to the existing CLI — everything new is additive under a namespaced `sdk.*` export.

Spec source: [`.genie/wishes/rlmx-sdk-upgrade/WISH.md`](../../khal-os/brain/blob/dev/.genie/wishes/rlmx-sdk-upgrade/WISH.md) Group 1.

## The 10 events

Followed the WISH.md enumeration **verbatim** — no inferences.

| Order | `type`            | Emitted when                                          |
| ----- | ----------------- | ----------------------------------------------------- |
| 1     | `AgentStart`      | Once per `runAgent()` before the first iteration.     |
| 2     | `IterationStart`  | At the top of each REPL iteration.                    |
| 3     | `IterationOutput` | After an iteration completes, with its output string. |
| 4     | `ToolCallBefore`  | Immediately before a tool invocation.                 |
| 5     | `ToolCallAfter`   | Immediately after a tool returns (success or error).  |
| 6     | `Recurse`         | On every `rlm_query` recursion, with depth metadata.  |
| 7     | `Validation`      | After an `emit_done` payload is schema-checked.       |
| 8     | `Message`         | For human-readable system / user / assistant turns.   |
| 9     | `EmitDone`        | When the agent signals completion with a payload.     |
| 10    | `Error`           | For non-fatal + fatal failures, tagged by phase.      |

Your dispatch listed 8 events and suggested `session_open` / `session_close` as two sensible inferences. I stayed with the WISH.md list instead — Session API is explicitly the Group 2 deliverable (WISH.md L22, L136–158), and the Session events will be defined there alongside `resumeAgent()` / `pauseAgent()` where they belong semantically. Flagging the call in case you want to override; happy to add them here if you'd rather front-load.

## Change shape (7 files, +734/-0)

| file | purpose |
|---|---|
| `src/sdk/events.ts` (new) | Discriminated union + per-variant interfaces + `makeEvent` helper + `isAgentEvent` guard + `ALL_AGENT_EVENT_TYPES` exhaustive sentinel + `iso()` timestamp helper. |
| `src/sdk/emitter.ts` (new) | `createEmitter()` returns a combined `EventEmitter + EventStream`. Fan-out to every active subscriber; pre-subscribe buffer replays **once** to the first subscriber only (no double-delivery). Idempotent `close()`; post-close emits drop silently. Directly iterable via `for await`. |
| `src/sdk/index.ts` (new) | Narrow public re-export so consumers depend on a stable surface as Groups 2–3 widen. |
| `src/index.ts` | Expose as `export * as sdk` — additive; no existing export shape changed. |
| `tests/sdk-events.test.ts` (new) | 6 tests: exact 10-name contract, `makeEvent` timestamp handling, full JSON round-trip per variant, `isAgentEvent` negative cases, `iso()` shape. |
| `tests/sdk-emitter.test.ts` (new) | 9 tests: in-order delivery, pre-subscribe buffer, no-double-deliver across subscribers, multi-subscriber fan-out, close semantics, await-then-emit flow, `for await` iteration, `iterator.return()` early-exit. |
| `docs/events.md` (new) | Short public doc with the catalogue table + scope boundary. |

## Verification

- `npm run check` (`tsc --noEmit`) → **clean**
- `npm run build` → ok
- `node --test dist/tests/sdk-events.test.js dist/tests/sdk-emitter.test.js` → **15 / 15 pass**
- `npm test` (full suite) → **220 / 220 pass** — zero regression in the existing 205 tests

## Scope boundary (out of this PR)

- `runAgent()` / `resumeAgent()` / `pauseAgent()` — Group 2
- Session lifecycle + REPL checkpointing — Group 2
- Permission hooks, `VALIDATE.md` primitive — Group 2
- Tool plugin loader, RTK native wiring — Group 3
- Per-depth metrics — Group 3
- Genie `RlmxExecutor` — Group 5
- Instrumentation of `src/rlm.ts` — Group 2

CLI (`rlmx "query" --context ./path`) is byte-for-byte unchanged.

## Base + head

- Base: `main` @ `c03679a` (rlmx has a `dev` branch too but the wish is clear that Groups 1-3 ship on main; per dispatch instruction)
- Head: `62a90f6`
- Branch: `feat/event-sdk-skeleton`

## Next after merge

Hand off to Group 2 (Session + Permission + Validate) per WISH.md L136.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event-stream capability enabling real-time consumption of agent execution events via async-iterators
  * 10 typed event variants with ISO-8601 timestamps covering the complete agent lifecycle

* **Documentation**
  * Comprehensive event-stream contract specification including TypeScript usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->