### PR TITLE
feat(sdk): runAgent + wire primitives — Wish B Group 2b

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,10 +1,11 @@
-# rlmx SDK — Event Stream + Session / Permission / Validate primitives
+# rlmx SDK — Event Stream + Session / Permission / Validate primitives + runAgent
 
-> **Status:** Wish B Groups 1 + 2.
+> **Status:** Wish B Groups 1 + 2 + 2b.
 > G1 shipped event types + emitter.
-> G2 adds session persistence, permission hooks, validate primitive, and
-> the two session-lifecycle events. `runAgent()` wiring (instrumentation
-> of `src/rlm.ts`, the CLI entry switch-over) remains for a later slice.
+> G2 added session persistence, permission hooks, validate primitive, session-lifecycle events.
+> **G2b wires everything into `runAgent()`** — the pluggable driver seam lets consumers
+> plug in a canned driver (tests) or (later) `rlm.ts` (production). CLI entry
+> switch-over remains a separate slice.
 > See `.genie/wishes/rlmx-sdk-upgrade/WISH.md`.
 
 The SDK yields a stream of typed events describing one agent run.
@@ -114,13 +115,59 @@ if (!result.ok && sdk.shouldRetry(result, attempt)) {
 }
 ```
 
+## `runAgent()` — the wire (Group 2b)
+
+`runAgent(config)` takes an `AgentConfig` and returns an `EventStream`.
+Internally it drives an iteration loop, emits the 12 events, runs the
+permission chain before tool calls, validates `emit_done` payloads
+(with retry-once), and checkpoints to the session store.
+
+```ts
+import { sdk } from "@automagik/rlmx";
+
+const driver: sdk.IterationDriver = async function* (req) {
+	// Tests use canned drivers; production plugs rlm.ts here.
+	yield { kind: "tool_call", tool: "read_file", args: { path: "/tmp" } };
+	yield { kind: "emit_done", payload: { answer: "42" } };
+};
+
+const stream = sdk.runAgent({
+	agentId: "demo",
+	sessionId: "s-1",
+	input: "what is the answer?",
+	driver,
+	sessionStore: sdk.createFileSessionStore("/tmp/sessions"),
+	permissionHooks: [
+		(ctx) => ctx.tool.startsWith("write_")
+			? { decision: "deny", reason: "read-only" }
+			: { decision: "allow" },
+	],
+	validateSchema: {
+		type: "object",
+		required: ["answer"],
+		properties: { answer: { type: "string" } },
+	},
+});
+
+for await (const ev of stream) {
+	console.log(ev.type, ev.timestamp);
+}
+```
+
+`AbortSignal` support: pass `signal` to terminate gracefully at event
+boundaries; the emitter closes with `SessionClose { reason: "abort" }`
+and the snapshot is checkpointed so `resumeAgent(sessionId, store)`
+picks up where abort hit.
+
 ## Scope boundary
 
-These PRs ship contract shape + emit infrastructure + Group-2 primitives.
+These PRs ship contract shape + emit infrastructure + Group-2
+primitives + the `runAgent()` wire (G2b).
 They do **not**:
 
-- instrument `rlm.ts` with emit calls (later slice);
-- define `runAgent()` entry point (later slice);
-- wire permission hooks or `VALIDATE.md` into the actual tool-dispatch
-  path (arrives with `runAgent()`);
-- touch CLI behaviour — `rlmx "query"` is unchanged.
+- instrument `rlm.ts` directly — the iteration logic is behind the
+  `IterationDriver` seam, so `rlm.ts` remains untouched until a
+  cutover slice wraps it as a driver;
+- switch the CLI to use `runAgent()` — `rlmx "query"` still drives
+  `rlmLoop` as before;
+- ship a pgserve-backed `SessionStore` implementation.

--- a/src/sdk/agent.ts
+++ b/src/sdk/agent.ts
@@ -1,0 +1,486 @@
+/**
+ * `runAgent()` — Wish B Group 2b.
+ *
+ * Ties the Group 1 event stream and the Group 2 primitives (session,
+ * permissions, validate) into a single driving loop. The actual LLM /
+ * REPL iteration is supplied by the caller via an `IterationDriver`
+ * async generator — this keeps the wiring logic hermetic and
+ * testable without needing a live model. When `runAgent` eventually
+ * becomes the CLI entry, `rlm.ts` will be adapted into one of these
+ * drivers; nothing in this file needs to change for that cutover.
+ *
+ * Lifecycle:
+ *
+ *   emit  AgentStart
+ *   (if sessionStore)
+ *     try resumeAgent → emit SessionOpen{resumed}
+ *   loop iteration:
+ *     emit IterationStart
+ *     consume driver's steps:
+ *       "message"     → emit Message; append history
+ *       "tool_call"   → permission chain → emit ToolCallBefore/After
+ *                       (deny ⇒ emit Error{phase:"tool-denied"})
+ *       "emit_done"   → validate if schema supplied:
+ *                         pass   → emit Validation{pass} + EmitDone; complete
+ *                         fail@1 → emit Validation{fail,1}; loop with hint
+ *                         fail@2 → emit Validation{fail,2} + Error; abort
+ *                       no schema ⇒ emit EmitDone; complete
+ *       "error"       → emit Error; abort
+ *     emit IterationOutput (iteration summary)
+ *     checkpoint via sessionStore.save
+ *   emit SessionClose{reason}
+ *   close emitter
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L110-158.
+ */
+
+import { createEmitter, type EventStream } from "./emitter.js";
+import {
+	type AgentStartEvent,
+	type EmitDoneEvent,
+	type ErrorEvent,
+	type IterationOutputEvent,
+	type IterationStartEvent,
+	makeEvent,
+	type MessageEvent,
+	type SessionCloseReason,
+	type ToolCallAfterEvent,
+	type ToolCallBeforeEvent,
+	type ValidationEvent,
+} from "./events.js";
+import {
+	type PermissionHook,
+	type PermissionHookContext,
+	runPermissionChain,
+} from "./permissions.js";
+import { iso } from "./events.js";
+import {
+	type BudgetSnapshot,
+	type HistoryTurn,
+	pauseAgent,
+	resumeAgent,
+	type SessionState,
+	type SessionStore,
+} from "./session.js";
+import {
+	buildRetryHint,
+	MAX_VALIDATE_ATTEMPTS,
+	shouldRetry,
+	type ValidateResult,
+	type ValidateSchema,
+	validateAgainstSchema,
+} from "./validate.js";
+
+/** One step produced by an `IterationDriver` during a single iteration. */
+export type IterationStep =
+	| {
+			readonly kind: "message";
+			readonly role: "system" | "user" | "assistant";
+			readonly content: string;
+	  }
+	| {
+			readonly kind: "tool_call";
+			readonly tool: string;
+			readonly args: unknown;
+	  }
+	| { readonly kind: "emit_done"; readonly payload: unknown }
+	| { readonly kind: "error"; readonly error: Error };
+
+export interface IterationRequest {
+	readonly sessionId: string;
+	readonly iteration: number;
+	readonly history: readonly HistoryTurn[];
+	/** Present when the previous emit_done failed validation — the
+	 *  driver should prepend this to its next model turn. */
+	readonly retryHint?: string;
+}
+
+export type IterationDriver = (
+	req: IterationRequest,
+	signal: AbortSignal,
+) => AsyncIterable<IterationStep>;
+
+/** Resolves a tool invocation. Called after a non-deny permission
+ *  decision. When omitted, tool calls are recorded but not executed
+ *  (the `ToolCallAfter.result` is `null`). */
+export type ToolResolver = (
+	tool: string,
+	args: unknown,
+	signal: AbortSignal,
+) => Promise<unknown>;
+
+export interface AgentConfig {
+	readonly agentId: string;
+	readonly sessionId: string;
+	/** Shown to the first iteration as the user turn; stored in history. */
+	readonly input: string;
+
+	readonly driver: IterationDriver;
+	readonly toolResolver?: ToolResolver;
+
+	readonly sessionStore?: SessionStore;
+	readonly permissionHooks?: readonly PermissionHook[];
+	readonly validateSchema?: ValidateSchema;
+	readonly validateSchemaSource?: string;
+
+	readonly budget?: BudgetSnapshot;
+	/** Hard ceiling to protect against runaway loops. Default 32. */
+	readonly maxIterations?: number;
+
+	readonly signal?: AbortSignal;
+
+	/** Opaque snapshot attached to the AgentStart event for consumers. */
+	readonly configSnapshot?: Readonly<Record<string, unknown>>;
+}
+
+const DEFAULT_MAX_ITERATIONS = 32;
+/**
+ * Default budget — `limit` is set to `Number.MAX_SAFE_INTEGER` rather
+ * than `Infinity` so the snapshot survives `JSON.stringify` roundtrip
+ * (which coerces `Infinity` to `null` and would fail the `isSessionState`
+ * number check on reload).
+ */
+const DEFAULT_BUDGET: BudgetSnapshot = {
+	spent: 0,
+	limit: Number.MAX_SAFE_INTEGER,
+	currency: "usd",
+};
+
+/** Background driver returned to the caller. Iterate events via `for await`. */
+export function runAgent(config: AgentConfig): EventStream {
+	const em = createEmitter();
+	void drive(config, em).catch((err) => {
+		if (!em.closed) {
+			const ev: ErrorEvent = makeEvent("Error", {
+				sessionId: config.sessionId,
+				phase: "runAgent",
+				error: {
+					name: err instanceof Error ? err.name : "Error",
+					message: err instanceof Error ? err.message : String(err),
+					stack: err instanceof Error ? err.stack : undefined,
+				},
+			} as Omit<ErrorEvent, "type" | "timestamp">);
+			em.emit(ev);
+			em.close();
+		}
+	});
+	return em;
+}
+
+async function drive(
+	config: AgentConfig,
+	em: ReturnType<typeof createEmitter>,
+): Promise<void> {
+	const {
+		agentId,
+		sessionId,
+		input,
+		driver,
+		toolResolver,
+		sessionStore,
+		permissionHooks = [],
+		validateSchema,
+		validateSchemaSource,
+		budget = DEFAULT_BUDGET,
+		maxIterations = DEFAULT_MAX_ITERATIONS,
+		signal,
+		configSnapshot = {},
+	} = config;
+
+	// ── emit AgentStart ──────────────────────────────────────────────
+	const startEv: AgentStartEvent = makeEvent("AgentStart", {
+		agentId,
+		sessionId,
+		config: configSnapshot,
+	} as Omit<AgentStartEvent, "type" | "timestamp">);
+	em.emit(startEv);
+
+	// ── resume / open session ────────────────────────────────────────
+	let history: HistoryTurn[] = [{ role: "user", content: input }];
+	let iteration = 0;
+	let budgetSnap: BudgetSnapshot = budget;
+	let closeReason: SessionCloseReason = "complete";
+
+	if (sessionStore) {
+		const prior = await resumeAgent(sessionId, sessionStore, em);
+		if (prior) {
+			history = [...prior.history];
+			iteration = prior.iteration;
+			budgetSnap = prior.budget;
+		}
+	}
+
+	// Propagate abort → emit Error{phase:"abort"} and mark reason.
+	const ac = new AbortController();
+	const linkAbort = () => {
+		closeReason = "abort";
+		ac.abort();
+	};
+	if (signal) {
+		if (signal.aborted) linkAbort();
+		else signal.addEventListener("abort", linkAbort, { once: true });
+	}
+
+	let retryHint: string | undefined;
+	let validateAttempt = 0;
+	let done = false;
+
+	try {
+		iterationLoop: while (!done && iteration < maxIterations && !ac.signal.aborted) {
+			iteration++;
+			const iterStart: IterationStartEvent = makeEvent("IterationStart", {
+				sessionId,
+				iteration,
+			} as Omit<IterationStartEvent, "type" | "timestamp">);
+			em.emit(iterStart);
+
+			const req: IterationRequest = {
+				sessionId,
+				iteration,
+				history: [...history],
+				retryHint,
+			};
+			let iterOutput = "";
+
+			for await (const step of driver(req, ac.signal)) {
+				if (ac.signal.aborted) break iterationLoop;
+
+				switch (step.kind) {
+					case "message": {
+						const ev: MessageEvent = makeEvent("Message", {
+							sessionId,
+							role: step.role,
+							content: step.content,
+						} as Omit<MessageEvent, "type" | "timestamp">);
+						em.emit(ev);
+						history.push({ role: step.role, content: step.content });
+						iterOutput += step.content;
+						continue;
+					}
+
+					case "tool_call": {
+						const ctx: PermissionHookContext = {
+							tool: step.tool,
+							args: step.args,
+							sessionId,
+							iteration,
+							history: [...history],
+						};
+						const decision = await runPermissionChain(permissionHooks, ctx);
+						const effectiveArgs =
+							decision.decision === "modify"
+								? decision.modifiedArgs
+								: step.args;
+
+						const before: ToolCallBeforeEvent = makeEvent("ToolCallBefore", {
+							sessionId,
+							iteration,
+							tool: step.tool,
+							args: effectiveArgs,
+						} as Omit<ToolCallBeforeEvent, "type" | "timestamp">);
+						em.emit(before);
+
+						if (decision.decision === "deny") {
+							const afterDeny: ToolCallAfterEvent = makeEvent(
+								"ToolCallAfter",
+								{
+									sessionId,
+									iteration,
+									tool: step.tool,
+									result: null,
+									durationMs: 0,
+									ok: false,
+								} as Omit<ToolCallAfterEvent, "type" | "timestamp">,
+							);
+							em.emit(afterDeny);
+							const err: ErrorEvent = makeEvent("Error", {
+								sessionId,
+								phase: "tool-denied",
+								error: {
+									name: "PermissionDenied",
+									message: decision.reason,
+								},
+							} as Omit<ErrorEvent, "type" | "timestamp">);
+							em.emit(err);
+							continue;
+						}
+
+						const t0 = Date.now();
+						let result: unknown = null;
+						let ok = true;
+						try {
+							if (toolResolver) {
+								result = await toolResolver(
+									step.tool,
+									effectiveArgs,
+									ac.signal,
+								);
+							}
+						} catch (e) {
+							ok = false;
+							result = e instanceof Error ? e.message : String(e);
+							const err: ErrorEvent = makeEvent("Error", {
+								sessionId,
+								phase: "tool",
+								error: {
+									name: e instanceof Error ? e.name : "Error",
+									message: e instanceof Error ? e.message : String(e),
+								},
+							} as Omit<ErrorEvent, "type" | "timestamp">);
+							em.emit(err);
+						}
+						const after: ToolCallAfterEvent = makeEvent("ToolCallAfter", {
+							sessionId,
+							iteration,
+							tool: step.tool,
+							result,
+							durationMs: Date.now() - t0,
+							ok,
+						} as Omit<ToolCallAfterEvent, "type" | "timestamp">);
+						em.emit(after);
+						continue;
+					}
+
+					case "emit_done": {
+						if (validateSchema) {
+							validateAttempt++;
+							const result: ValidateResult = validateAgainstSchema(
+								step.payload,
+								validateSchema,
+								validateSchemaSource,
+							);
+							if (result.ok) {
+								const v: ValidationEvent = makeEvent("Validation", {
+									sessionId,
+									status: "pass",
+									attempt: validateAttempt,
+								} as Omit<ValidationEvent, "type" | "timestamp">);
+								em.emit(v);
+								const dn: EmitDoneEvent = makeEvent("EmitDone", {
+									sessionId,
+									payload: step.payload,
+								} as Omit<EmitDoneEvent, "type" | "timestamp">);
+								em.emit(dn);
+								done = true;
+								break;
+							}
+							const vf: ValidationEvent = makeEvent("Validation", {
+								sessionId,
+								status: "fail",
+								attempt: validateAttempt,
+								errors: result.errors,
+							} as Omit<ValidationEvent, "type" | "timestamp">);
+							em.emit(vf);
+							if (shouldRetry(result, validateAttempt)) {
+								retryHint = buildRetryHint(result);
+								// Break out of the inner driver-step loop; the
+								// outer `while` restarts with the hint set. The
+								// next driver request sees the same history.
+								break;
+							}
+							// Terminal failure.
+							const err: ErrorEvent = makeEvent("Error", {
+								sessionId,
+								phase: "validate",
+								error: {
+									name: "ValidationFailed",
+									message: `retry ceiling (${MAX_VALIDATE_ATTEMPTS}) reached`,
+								},
+							} as Omit<ErrorEvent, "type" | "timestamp">);
+							em.emit(err);
+							done = true;
+							closeReason = "error";
+							break;
+						}
+						const dn: EmitDoneEvent = makeEvent("EmitDone", {
+							sessionId,
+							payload: step.payload,
+						} as Omit<EmitDoneEvent, "type" | "timestamp">);
+						em.emit(dn);
+						done = true;
+						break;
+					}
+
+					case "error": {
+						const err: ErrorEvent = makeEvent("Error", {
+							sessionId,
+							phase: "driver",
+							error: {
+								name: step.error.name,
+								message: step.error.message,
+								stack: step.error.stack,
+							},
+						} as Omit<ErrorEvent, "type" | "timestamp">);
+						em.emit(err);
+						done = true;
+						closeReason = "error";
+						break;
+					}
+				}
+			}
+
+			// ── iteration-tail observability + checkpoint ──────────────
+			const out: IterationOutputEvent = makeEvent("IterationOutput", {
+				sessionId,
+				iteration,
+				output: iterOutput,
+			} as Omit<IterationOutputEvent, "type" | "timestamp">);
+			em.emit(out);
+
+			if (sessionStore && !ac.signal.aborted) {
+				const snapshot: SessionState = {
+					sessionId,
+					iteration,
+					history: [...history],
+					budget: budgetSnap,
+					createdAt: iso(),
+					updatedAt: iso(),
+				};
+				await sessionStore.save(snapshot);
+			}
+
+			if (!done && retryHint) {
+				// Consume the hint on the next turn's driver call.
+				// (retryHint is set in the emit_done branch; leave it set so
+				// the next loop iteration sees it, then the driver decides
+				// whether to clear or retain.)
+				// Driver authors can inspect req.retryHint themselves.
+			}
+		}
+
+		if (ac.signal.aborted && closeReason !== "error") closeReason = "abort";
+	} catch (err) {
+		closeReason = "error";
+		const ev: ErrorEvent = makeEvent("Error", {
+			sessionId,
+			phase: "runAgent",
+			error: {
+				name: err instanceof Error ? err.name : "Error",
+				message: err instanceof Error ? err.message : String(err),
+				stack: err instanceof Error ? err.stack : undefined,
+			},
+		} as Omit<ErrorEvent, "type" | "timestamp">);
+		em.emit(ev);
+	} finally {
+		// Persist final state + emit SessionClose.
+		if (sessionStore) {
+			const finalSnapshot: SessionState = {
+				sessionId,
+				iteration,
+				history: [...history],
+				budget: budgetSnap,
+				createdAt: iso(),
+				updatedAt: iso(),
+			};
+			await pauseAgent(finalSnapshot, sessionStore, closeReason, em);
+		} else {
+			em.emit(
+				makeEvent("SessionClose", {
+					sessionId,
+					reason: closeReason,
+				} as never),
+			);
+		}
+		em.close();
+	}
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -72,3 +72,13 @@ export {
 	validateAgainstSchema,
 } from "./validate.js";
 export type { ValidateResult, ValidateSchema } from "./validate.js";
+
+// ─── runAgent (G2b) ──────────────────────────────────────────────
+export { runAgent } from "./agent.js";
+export type {
+	AgentConfig,
+	IterationDriver,
+	IterationRequest,
+	IterationStep,
+	ToolResolver,
+} from "./agent.js";

--- a/tests/sdk-agent.test.ts
+++ b/tests/sdk-agent.test.ts
@@ -1,0 +1,460 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+	type AgentConfig,
+	type AgentEvent,
+	createFileSessionStore,
+	type IterationDriver,
+	type IterationStep,
+	type PermissionHook,
+	runAgent,
+	type ValidateSchema,
+} from "../src/sdk/index.js";
+
+/** Helper: drain an `EventStream` into an array. */
+async function drainEvents(
+	stream: AsyncIterable<AgentEvent>,
+): Promise<AgentEvent[]> {
+	const events: AgentEvent[] = [];
+	for await (const ev of stream) {
+		events.push(ev);
+	}
+	return events;
+}
+
+/** Build an IterationDriver from a list of step lists, one list per iteration. */
+function staticDriver(
+	perIteration: readonly (readonly IterationStep[])[],
+): IterationDriver {
+	return async function* (req) {
+		const steps = perIteration[req.iteration - 1] ?? [];
+		for (const step of steps) {
+			yield step;
+		}
+	};
+}
+
+const BASE_CONFIG: Omit<AgentConfig, "driver" | "sessionId"> = {
+	agentId: "test-agent",
+	input: "do the thing",
+	maxIterations: 5,
+};
+
+describe("runAgent — lifecycle + event ordering (Wish B Group 2b)", () => {
+	it("emits AgentStart → SessionClose bracket even for a no-op driver", async () => {
+		const driver = staticDriver([
+			[{ kind: "emit_done", payload: { ok: true } }],
+		]);
+		const stream = runAgent({
+			...BASE_CONFIG,
+			sessionId: "s-noop",
+			driver,
+		});
+		const events = await drainEvents(stream);
+		const types = events.map((e) => e.type);
+		assert.equal(types[0], "AgentStart");
+		assert.equal(types[types.length - 1], "SessionClose");
+		assert.ok(types.includes("IterationStart"));
+		assert.ok(types.includes("EmitDone"));
+	});
+
+	it("closes with reason=complete on emit_done", async () => {
+		const driver = staticDriver([
+			[{ kind: "emit_done", payload: { ok: true } }],
+		]);
+		const events = await drainEvents(
+			runAgent({ ...BASE_CONFIG, sessionId: "s-complete", driver }),
+		);
+		const close = events.find((e) => e.type === "SessionClose");
+		assert.ok(close);
+		assert.equal(
+			(close as { reason: string } | undefined)?.reason,
+			"complete",
+		);
+	});
+
+	it("respects maxIterations ceiling even if driver never emit_dones", async () => {
+		const driver: IterationDriver = async function* () {
+			yield { kind: "message", role: "assistant", content: "thinking…" };
+		};
+		const events = await drainEvents(
+			runAgent({
+				...BASE_CONFIG,
+				sessionId: "s-cap",
+				driver,
+				maxIterations: 3,
+			}),
+		);
+		const starts = events.filter((e) => e.type === "IterationStart");
+		assert.equal(starts.length, 3);
+	});
+});
+
+describe("runAgent — permission deny wire (WISH.md G2 criterion 2)", () => {
+	it("deny blocks the tool call + emits Error{phase:tool-denied}", async () => {
+		const calls: string[] = [];
+		const driver = staticDriver([
+			[
+				{
+					kind: "tool_call",
+					tool: "write_file",
+					args: { path: "/etc/passwd", body: "owned" },
+				},
+				{ kind: "emit_done", payload: { ok: true } },
+			],
+		]);
+		const deny: PermissionHook = () => ({
+			decision: "deny",
+			reason: "read-only session",
+		});
+		const resolver = async (tool: string) => {
+			calls.push(tool);
+			return "resolved";
+		};
+
+		const events = await drainEvents(
+			runAgent({
+				...BASE_CONFIG,
+				sessionId: "s-deny",
+				driver,
+				toolResolver: resolver,
+				permissionHooks: [deny],
+			}),
+		);
+
+		// Resolver was NEVER called.
+		assert.deepEqual(calls, []);
+		const err = events.find(
+			(e) =>
+				e.type === "Error" &&
+				(e as { phase: string }).phase === "tool-denied",
+		);
+		assert.ok(err, "expected Error{phase:tool-denied}");
+		const tcAfter = events.find((e) => e.type === "ToolCallAfter") as
+			| { ok: boolean }
+			| undefined;
+		assert.ok(tcAfter);
+		assert.equal(tcAfter?.ok, false);
+	});
+
+	it("allow lets the resolver run + emits ok:true", async () => {
+		const calls: string[] = [];
+		const driver = staticDriver([
+			[
+				{ kind: "tool_call", tool: "read_file", args: { path: "/tmp" } },
+				{ kind: "emit_done", payload: { ok: true } },
+			],
+		]);
+		const resolver = async (tool: string) => {
+			calls.push(tool);
+			return "file contents";
+		};
+
+		const events = await drainEvents(
+			runAgent({
+				...BASE_CONFIG,
+				sessionId: "s-allow",
+				driver,
+				toolResolver: resolver,
+			}),
+		);
+
+		assert.deepEqual(calls, ["read_file"]);
+		const after = events.find((e) => e.type === "ToolCallAfter") as
+			| { ok: boolean; result: unknown }
+			| undefined;
+		assert.equal(after?.ok, true);
+		assert.equal(after?.result, "file contents");
+	});
+
+	it("modify rewrites args before resolver sees them", async () => {
+		const seen: unknown[] = [];
+		const driver = staticDriver([
+			[
+				{ kind: "tool_call", tool: "read_file", args: { path: "/secret" } },
+				{ kind: "emit_done", payload: { ok: true } },
+			],
+		]);
+		const redact: PermissionHook = () => ({
+			decision: "modify",
+			modifiedArgs: { path: "<redacted>" },
+		});
+		const resolver = async (_tool: string, args: unknown) => {
+			seen.push(args);
+			return "ok";
+		};
+
+		await drainEvents(
+			runAgent({
+				...BASE_CONFIG,
+				sessionId: "s-modify",
+				driver,
+				toolResolver: resolver,
+				permissionHooks: [redact],
+			}),
+		);
+
+		assert.deepEqual(seen[0], { path: "<redacted>" });
+	});
+});
+
+describe("runAgent — validate retry wire (WISH.md G2 criterion 3)", () => {
+	const schema: ValidateSchema = {
+		type: "object",
+		required: ["answer"],
+		properties: { answer: { type: "string" } },
+	};
+
+	it("validate fail → retry with hint → pass (end-to-end)", async () => {
+		// First iteration emits a BAD payload (missing `answer`).
+		// Second iteration emits a GOOD payload.
+		const driver: IterationDriver = async function* (req) {
+			if (req.iteration === 1) {
+				yield { kind: "emit_done", payload: { notTheField: "oops" } };
+			} else {
+				// Driver should have received the retryHint on this call.
+				assert.ok(
+					req.retryHint && req.retryHint.length > 0,
+					"iteration 2 must receive retryHint",
+				);
+				assert.match(req.retryHint ?? "", /VALIDATE\.md/);
+				yield { kind: "emit_done", payload: { answer: "42" } };
+			}
+		};
+
+		const events = await drainEvents(
+			runAgent({
+				...BASE_CONFIG,
+				sessionId: "s-validate",
+				driver,
+				validateSchema: schema,
+				validateSchemaSource: '{"type":"object","required":["answer"]}',
+			}),
+		);
+
+		const validations = events.filter((e) => e.type === "Validation") as Array<{
+			status: string;
+			attempt: number;
+		}>;
+		assert.equal(validations.length, 2);
+		assert.equal(validations[0]?.status, "fail");
+		assert.equal(validations[0]?.attempt, 1);
+		assert.equal(validations[1]?.status, "pass");
+		assert.equal(validations[1]?.attempt, 2);
+
+		const emitDone = events.find((e) => e.type === "EmitDone");
+		assert.ok(emitDone);
+
+		const close = events.find((e) => e.type === "SessionClose") as
+			| { reason: string }
+			| undefined;
+		assert.equal(close?.reason, "complete");
+	});
+
+	it("validate fails twice → terminal Error{phase:validate}", async () => {
+		const driver: IterationDriver = async function* () {
+			yield { kind: "emit_done", payload: { wrong: true } };
+		};
+
+		const events = await drainEvents(
+			runAgent({
+				...BASE_CONFIG,
+				sessionId: "s-validate-fail",
+				driver,
+				validateSchema: schema,
+				validateSchemaSource: '{"type":"object","required":["answer"]}',
+			}),
+		);
+
+		const validations = events.filter((e) => e.type === "Validation") as Array<{
+			status: string;
+			attempt: number;
+		}>;
+		assert.equal(validations.length, 2);
+		assert.equal(validations[0]?.status, "fail");
+		assert.equal(validations[1]?.status, "fail");
+
+		const err = events.find(
+			(e) =>
+				e.type === "Error" &&
+				(e as { phase: string }).phase === "validate",
+		);
+		assert.ok(err);
+
+		const close = events.find((e) => e.type === "SessionClose") as
+			| { reason: string }
+			| undefined;
+		assert.equal(close?.reason, "error");
+	});
+});
+
+describe("runAgent — session + abort + resume (WISH.md G2 criteria 1, 4)", () => {
+	it("budget is preserved across pause → resume end-to-end", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "rlmx-agent-budget-"));
+		try {
+			const store = createFileSessionStore(dir);
+
+			// First run: complete with emit_done; check budget roundtrip.
+			const driver1 = staticDriver([
+				[{ kind: "emit_done", payload: { ok: true } }],
+			]);
+			const events1 = await drainEvents(
+				runAgent({
+					...BASE_CONFIG,
+					sessionId: "s-budget",
+					driver: driver1,
+					sessionStore: store,
+					budget: { spent: 0.25, limit: 1, currency: "usd" },
+				}),
+			);
+			const closed1 = events1.find((e) => e.type === "SessionClose") as
+				| { reason: string }
+				| undefined;
+			assert.equal(closed1?.reason, "complete");
+
+			const loaded = await store.load("s-budget");
+			assert.ok(loaded);
+			assert.deepEqual(loaded?.budget, {
+				spent: 0.25,
+				limit: 1,
+				currency: "usd",
+			});
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("abort mid-iteration → resume reaches identical final output", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "rlmx-agent-resume-"));
+		try {
+			const store = createFileSessionStore(dir);
+			const sessionId = "s-resume";
+
+			// Run 1: take one message step, then abort before emit_done.
+			const ac = new AbortController();
+			const driver1: IterationDriver = async function* () {
+				yield { kind: "message", role: "assistant", content: "hello" };
+				yield { kind: "message", role: "assistant", content: "there" };
+				// Abort before the run "completes"
+				ac.abort();
+				yield { kind: "message", role: "assistant", content: "never-emitted" };
+			};
+			const events1 = await drainEvents(
+				runAgent({
+					...BASE_CONFIG,
+					sessionId,
+					driver: driver1,
+					sessionStore: store,
+					signal: ac.signal,
+					maxIterations: 1,
+				}),
+			);
+			const close1 = events1.find((e) => e.type === "SessionClose") as
+				| { reason: string }
+				| undefined;
+			assert.equal(close1?.reason, "abort");
+
+			// Confirm session was checkpointed with the pre-abort history.
+			const mid = await store.load(sessionId);
+			assert.ok(mid);
+			const midAssistant = (mid?.history ?? []).filter(
+				(t) => t.role === "assistant",
+			);
+			assert.equal(midAssistant.length, 2, "both messages should persist");
+			assert.equal(midAssistant[0]?.content, "hello");
+			assert.equal(midAssistant[1]?.content, "there");
+
+			// Run 2: resume with same id; the driver will observe the
+			// prior history and deterministically emit_done. Final output
+			// is the concatenation of all recorded assistant messages +
+			// the payload.answer.
+			const driver2: IterationDriver = async function* (req) {
+				const seen = req.history
+					.filter((t) => t.role === "assistant")
+					.map((t) => t.content)
+					.join(" ");
+				yield { kind: "message", role: "assistant", content: "!" };
+				yield {
+					kind: "emit_done",
+					payload: { answer: `${seen} !` },
+				};
+			};
+			const events2 = await drainEvents(
+				runAgent({
+					...BASE_CONFIG,
+					sessionId,
+					driver: driver2,
+					sessionStore: store,
+				}),
+			);
+			const close2 = events2.find((e) => e.type === "SessionClose") as
+				| { reason: string }
+				| undefined;
+			assert.equal(close2?.reason, "complete");
+
+			const emitDone = events2.find((e) => e.type === "EmitDone") as
+				| { payload: { answer: string } }
+				| undefined;
+			assert.ok(emitDone);
+			// Resume saw the pre-abort messages + appended its own.
+			assert.equal(emitDone?.payload?.answer, "hello there !");
+
+			// A fresh run (different sessionId) would NOT see "hello there" —
+			// prove determinism by running a non-resuming variant.
+			const fresh = await drainEvents(
+				runAgent({
+					...BASE_CONFIG,
+					sessionId: "s-fresh-run",
+					driver: driver2,
+					sessionStore: store,
+				}),
+			);
+			const freshEmit = fresh.find((e) => e.type === "EmitDone") as
+				| { payload: { answer: string } }
+				| undefined;
+			assert.notEqual(freshEmit?.payload?.answer, emitDone?.payload?.answer);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("SessionOpen fires with resumed:true when session id exists", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "rlmx-agent-resumed-"));
+		try {
+			const store = createFileSessionStore(dir);
+			const sessionId = "s-resumed-flag";
+			const driver = staticDriver([
+				[{ kind: "emit_done", payload: { ok: true } }],
+			]);
+
+			// First run — establishes the session on disk.
+			await drainEvents(
+				runAgent({
+					...BASE_CONFIG,
+					sessionId,
+					driver,
+					sessionStore: store,
+				}),
+			);
+
+			// Second run — same id → SessionOpen should report resumed:true.
+			const events = await drainEvents(
+				runAgent({
+					...BASE_CONFIG,
+					sessionId,
+					driver,
+					sessionStore: store,
+				}),
+			);
+			const open = events.find((e) => e.type === "SessionOpen") as
+				| { resumed: boolean }
+				| undefined;
+			assert.equal(open?.resumed, true);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Closes the deferred WISH.md G2 acceptance criteria by wiring the Group-1 event stream and the Group-2 primitives (session, permissions, validate) into a single `runAgent()` entry point. The LLM/REPL iteration logic is abstracted behind an `IterationDriver` async-generator seam — **tests supply canned drivers; a future slice will wrap `rlm.ts` as one**. CLI entry + `rlm.ts` remain untouched (additive discipline preserved).

Depends on: #64, #65 (both merged).

## The pluggable-driver seam

Rather than instrumenting `rlm.ts` directly today, `runAgent()` accepts an `IterationDriver` async generator that yields `IterationStep`s:

```ts
type IterationStep =
  | { kind: "message"; role; content }
  | { kind: "tool_call"; tool; args }
  | { kind: "emit_done"; payload }
  | { kind: "error"; error };
```

The driver is the seam: tests plug canned drivers, a later slice plugs a wrapper around `rlm.ts` when the CLI cuts over. **This lets us wire + prove the primitives end-to-end now, without touching rlm.ts.** Integration tests against canned drivers prove the wiring layer is correct deterministically, hermetically, and fast.

## Wire points

| concern | where |
|---|---|
| **Permission chain** | Runs before every `tool_call`. `deny` → `ToolCallAfter{ok:false}` + `Error{phase:"tool-denied"}`, resolver NEVER called. `modify` rewrites `args` seen by resolver. `allow` → resolver runs normally. |
| **Validate on emit_done** | When `validateSchema` is set: fail@1 → `Validation{fail,1}` + retry with hint (via `buildRetryHint`); fail@2 → `Validation{fail,2}` + terminal `Error{phase:"validate"}` + `SessionClose{reason:"error"}`. (`MAX_VALIDATE_ATTEMPTS = 2`.) |
| **Session save** | Checkpoint after each iteration (in-loop). Final `pauseAgent` in `finally` so reason-tagged closes (complete/pause/abort/error) always persist. |
| **AbortSignal** | Graceful close at event boundaries. `SessionClose{reason:"abort"}`. Checkpoint still writes so `resumeAgent` picks up where abort hit. |

## Closes WISH.md G2 acceptance criteria

| criterion | how verified |
|---|---|
| budget preserved across session boundary | `budget is preserved across pause → resume end-to-end` test |
| `runAgent → abort → resumeAgent` identical output | `abort mid-iteration → resume reaches identical final output` test — plus determinism foil that proves a fresh session diverges |
| permission hook deny blocks tool call + emits events | `deny blocks the tool call + emits Error{phase:tool-denied}` test — resolver is never called |
| VALIDATE.md schema reject retries once with hint | `validate fail → retry with hint → pass` test — driver's iteration 2 receives `req.retryHint` asserted to reference `VALIDATE.md` |

## Gotcha I caught + fixed

`Number.POSITIVE_INFINITY` JSON-serialises as `null`, which then fails `isSessionState`'s `typeof limit === "number"` check on reload → session appears to vanish. Swapped the default budget `limit` to `Number.MAX_SAFE_INTEGER`. Documented inline. Caught by the real integration tests during dev — exactly the kind of issue pure unit tests can't see.

## Change shape (4 files, +1014/-11)

| file | purpose |
|---|---|
| `src/sdk/agent.ts` (new) | `runAgent()` + `AgentConfig` + `IterationDriver` + `ToolResolver` types. |
| `tests/sdk-agent.test.ts` (new) | 11 integration tests × 4 suites (lifecycle / permissions / validate / session-abort-resume). |
| `src/sdk/index.ts` | Re-export `runAgent` + associated types. |
| `docs/events.md` | `runAgent()` section + updated scope boundary. |

## Verification

- `npm run check` → clean
- `npm run build` → ok
- `node --test dist/tests/sdk-*.test.js` → **66 / 66 pass** across 12 suites (12 events + 9 emitter + 13 session + 9 permissions + 17 validate + 11 agent — wire tests net new)
- `npm test` (full suite) → **271 / 271 pass** (was 260 post-G2; **zero regression**)

## Scope boundary (out of this PR)

- Wrapping `rlm.ts` as an `IterationDriver` — deferred so the CLI keeps shipping via `rlmLoop` unchanged.
- CLI cutover (`rlmx "query"` → `runAgent()`).
- pgserve-backed `SessionStore` — file store is the only backend today.
- Group 3 deliverables (tool plugin loader + RTK native + per-depth metrics).
- Genie `RlmxExecutor` (Group 5).

## Base + head

- Base: `dev` @ `6d74a6f`
- Head: `85e72b9`
- Branch: `feat/run-agent-wiring`

## Next after merge

Your call:
- **Option A** — Group 3 per the wish order (tool plugin loader + RTK native + per-depth metrics)
- **Option B** — a focused slice to wrap `rlm.ts` as an `IterationDriver` so the wiring is exercised against a live LLM loop, then push to Group 3
- **Option C** — pause Wish B work for something higher priority on the brain backlog