### PR TITLE
feat(sdk): rlmDriver — live-LLM adapter for runAgent

### DIFF
--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -82,3 +82,7 @@ export type {
 	IterationStep,
 	ToolResolver,
 } from "./agent.js";
+
+// ─── rlmDriver (G2c — real LLM bridge) ───────────────────────────
+export { formatRlmPrompt, rlmDriver } from "./rlm-driver.js";
+export type { RlmDriverConfig } from "./rlm-driver.js";

--- a/src/sdk/rlm-driver.ts
+++ b/src/sdk/rlm-driver.ts
@@ -1,0 +1,142 @@
+/**
+ * rlm-driver — Wish B Group 2b/c.
+ *
+ * Adapts the rlmx LLM backend (`llmCompleteSimple` from `src/llm.ts`)
+ * to the `IterationDriver` contract defined in `src/sdk/agent.ts`.
+ * Lets `runAgent()` drive a real LLM end-to-end so permissions,
+ * validate, session, and events tick through with production-shaped
+ * responses instead of canned fixtures.
+ *
+ * Design constraints:
+ *
+ *   • Zero touch to `src/rlm.ts` — the existing CLI entry (`rlmLoop`)
+ *     stays byte-for-byte unchanged. This module is additive.
+ *   • Shares the same LLM transport (`llmCompleteSimple`) rlm.ts uses,
+ *     so any provider / thinking-level / budget work that lands in
+ *     `llm.ts` automatically benefits this driver.
+ *   • Keeps the surface minimal: one LLM call per iteration, full
+ *     response surfaced as a `Message` event, terminal `emit_done`
+ *     with the response as payload. Parsing `rlmx`-specific Python
+ *     tool-call code blocks is deliberately NOT done here — that's a
+ *     larger slice that also requires a REPL executor. This driver
+ *     proves the wiring; a follow-up can layer tool dispatch on top.
+ *
+ * Consumers compose it via `runAgent({ driver: rlmDriver(cfg) })` —
+ * never called directly by user code.
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L93 (wave 5
+ * dogfood), plus the "prove end-to-end wiring against real LLM"
+ * mandate added in the G2b review cycle.
+ */
+
+import type { ModelConfig } from "../config.js";
+import { llmCompleteSimple, type LLMResponse } from "../llm.js";
+import type { IterationDriver, IterationRequest } from "./agent.js";
+
+export interface RlmDriverConfig {
+	/** Model config — same shape rlm.ts uses. */
+	readonly model: ModelConfig;
+	/** Optional SYSTEM.md contents; prepended to each turn's prompt. */
+	readonly system?: string;
+	/**
+	 * Injectable LLM completion fn. Defaults to the real
+	 * `llmCompleteSimple` so production just calls Gemini. Tests pass a
+	 * mock to validate the driver's event sequence without a live model.
+	 */
+	readonly llm?: (
+		prompt: string,
+		modelConfig: ModelConfig,
+		signal?: AbortSignal,
+	) => Promise<LLMResponse>;
+	/**
+	 * Hook for retry hints. When present, the driver injects the hint
+	 * into the prompt prefix on iterations where `req.retryHint` is
+	 * set by the runAgent validate pipeline. Default: prepends a
+	 * labelled block.
+	 */
+	readonly retryHintFormatter?: (hint: string) => string;
+}
+
+const DEFAULT_RETRY_FORMATTER = (hint: string): string =>
+	`# Retry hint from the validator\n\n${hint}\n\n`;
+
+/**
+ * Render the iteration's prompt. Keeps it intentionally simple — the
+ * driver's job is to get a response surface, not to reproduce the
+ * full SYSTEM.md / TOOLS.md / CRITERIA.md synthesis rlm.ts does.
+ * Callers needing the full rlm.ts prompt stack should wait for the
+ * CLI-cutover slice.
+ */
+export function formatRlmPrompt(
+	config: RlmDriverConfig,
+	req: IterationRequest,
+): string {
+	const parts: string[] = [];
+	if (config.system) {
+		parts.push(config.system.trim());
+	}
+	if (req.retryHint && req.retryHint.length > 0) {
+		const formatter = config.retryHintFormatter ?? DEFAULT_RETRY_FORMATTER;
+		parts.push(formatter(req.retryHint));
+	}
+	// Fold the user's input + any prior assistant turns into the prompt
+	// body. First history entry is always the initial user input (runAgent
+	// guarantees this); later assistant turns are appended so the model
+	// has continuity across iterations.
+	for (const turn of req.history) {
+		const label =
+			turn.role === "assistant"
+				? "Assistant"
+				: turn.role === "system"
+					? "System"
+					: "User";
+		parts.push(`${label}: ${turn.content}`);
+	}
+	return parts.join("\n\n");
+}
+
+/**
+ * Build an `IterationDriver` that drives one LLM call per iteration.
+ * The returned async generator yields a single `message` step with the
+ * full response text followed by an `emit_done` step carrying the
+ * response as a structured payload: `{ answer: string; usage: UsageStats }`.
+ *
+ * When the LLM fails (throws, or returns an empty string), the driver
+ * yields an `error` step so `runAgent` can surface it as `Error{phase:"driver"}`
+ * and close the session with `reason: "error"`.
+ */
+export function rlmDriver(config: RlmDriverConfig): IterationDriver {
+	const llm = config.llm ?? llmCompleteSimple;
+	return async function* (req, signal) {
+		const prompt = formatRlmPrompt(config, req);
+		let response: LLMResponse;
+		try {
+			response = await llm(prompt, config.model, signal);
+		} catch (err) {
+			yield {
+				kind: "error",
+				error: err instanceof Error ? err : new Error(String(err)),
+			};
+			return;
+		}
+
+		const text = (response.text ?? "").trim();
+		if (text.length === 0) {
+			yield {
+				kind: "error",
+				error: new Error("rlmDriver: LLM returned empty response"),
+			};
+			return;
+		}
+
+		yield { kind: "message", role: "assistant", content: text };
+		yield {
+			kind: "emit_done",
+			payload: {
+				answer: text,
+				usage: response.usage,
+				iteration: req.iteration,
+			},
+		};
+	};
+}

--- a/tests/sdk-rlm-driver.test.ts
+++ b/tests/sdk-rlm-driver.test.ts
@@ -1,0 +1,356 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createUsage, type LLMResponse } from "../src/llm.js";
+import type { ModelConfig } from "../src/config.js";
+import {
+	type AgentEvent,
+	formatRlmPrompt,
+	type IterationRequest,
+	type IterationStep,
+	rlmDriver,
+	runAgent,
+} from "../src/sdk/index.js";
+
+type LlmFn = (
+	prompt: string,
+	modelConfig: ModelConfig,
+	signal?: AbortSignal,
+) => Promise<LLMResponse>;
+
+const MODEL: ModelConfig = {
+	provider: "anthropic",
+	model: "claude-haiku-4-5",
+};
+
+function fakeLLM(text: string): {
+	fn: LlmFn;
+	seen: { prompts: string[] };
+} {
+	const seen = { prompts: [] as string[] };
+	return {
+		seen,
+		fn: async (prompt) => {
+			seen.prompts.push(prompt);
+			return { text, usage: createUsage() };
+		},
+	};
+}
+
+function failingLLM(err: Error): LlmFn {
+	return async () => {
+		throw err;
+	};
+}
+
+async function drain(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+	const events: AgentEvent[] = [];
+	for await (const ev of stream) events.push(ev);
+	return events;
+}
+
+describe("formatRlmPrompt — prompt synthesis", () => {
+	it("includes system prompt when supplied", () => {
+		const req: IterationRequest = {
+			sessionId: "s",
+			iteration: 1,
+			history: [{ role: "user", content: "hi" }],
+		};
+		const out = formatRlmPrompt(
+			{ model: MODEL, system: "You are a helpful assistant." },
+			req,
+		);
+		assert.match(out, /You are a helpful assistant\./);
+		assert.match(out, /User: hi/);
+	});
+
+	it("omits system block when not supplied", () => {
+		const req: IterationRequest = {
+			sessionId: "s",
+			iteration: 1,
+			history: [{ role: "user", content: "hi" }],
+		};
+		const out = formatRlmPrompt({ model: MODEL }, req);
+		assert.equal(out, "User: hi");
+	});
+
+	it("injects retryHint when runAgent supplied one", () => {
+		const req: IterationRequest = {
+			sessionId: "s",
+			iteration: 2,
+			history: [{ role: "user", content: "hi" }],
+			retryHint: "Your previous emit_done did not match VALIDATE.md: answer missing",
+		};
+		const out = formatRlmPrompt({ model: MODEL }, req);
+		assert.match(out, /Retry hint from the validator/);
+		assert.match(out, /VALIDATE\.md/);
+	});
+
+	it("folds multi-turn history with role labels", () => {
+		const req: IterationRequest = {
+			sessionId: "s",
+			iteration: 3,
+			history: [
+				{ role: "user", content: "step one" },
+				{ role: "assistant", content: "ok step one done" },
+				{ role: "user", content: "step two" },
+			],
+		};
+		const out = formatRlmPrompt({ model: MODEL }, req);
+		assert.match(out, /User: step one/);
+		assert.match(out, /Assistant: ok step one done/);
+		assert.match(out, /User: step two/);
+	});
+
+	it("custom retryHintFormatter is honoured", () => {
+		const req: IterationRequest = {
+			sessionId: "s",
+			iteration: 2,
+			history: [{ role: "user", content: "hi" }],
+			retryHint: "bad payload",
+		};
+		const out = formatRlmPrompt(
+			{
+				model: MODEL,
+				retryHintFormatter: (h) => `!!! ${h} !!!`,
+			},
+			req,
+		);
+		assert.match(out, /!!! bad payload !!!/);
+	});
+});
+
+describe("rlmDriver — step shape (hermetic)", () => {
+	it("yields message + emit_done for a non-empty response", async () => {
+		const { fn } = fakeLLM("The answer is 42.");
+		const driver = rlmDriver({ model: MODEL, llm: fn });
+		const req: IterationRequest = {
+			sessionId: "s",
+			iteration: 1,
+			history: [{ role: "user", content: "what is the answer?" }],
+		};
+		const ac = new AbortController();
+		const steps: IterationStep[] = [];
+		for await (const step of driver(req, ac.signal)) steps.push(step);
+		assert.equal(steps.length, 2);
+		assert.equal(steps[0]?.kind, "message");
+		assert.equal((steps[0] as { content: string }).content, "The answer is 42.");
+		assert.equal(steps[1]?.kind, "emit_done");
+		const payload = (steps[1] as { payload: { answer: string } }).payload;
+		assert.equal(payload.answer, "The answer is 42.");
+	});
+
+	it("yields an error step when the LLM throws", async () => {
+		const driver = rlmDriver({
+			model: MODEL,
+			llm: failingLLM(new Error("provider 429")),
+		});
+		const req: IterationRequest = {
+			sessionId: "s",
+			iteration: 1,
+			history: [{ role: "user", content: "hi" }],
+		};
+		const ac = new AbortController();
+		const steps: IterationStep[] = [];
+		for await (const step of driver(req, ac.signal)) steps.push(step);
+		assert.equal(steps.length, 1);
+		assert.equal(steps[0]?.kind, "error");
+		assert.equal(
+			(steps[0] as { error: Error }).error.message,
+			"provider 429",
+		);
+	});
+
+	it("yields an error step when the LLM returns empty text", async () => {
+		const { fn } = fakeLLM("   \n  ");
+		const driver = rlmDriver({ model: MODEL, llm: fn });
+		const req: IterationRequest = {
+			sessionId: "s",
+			iteration: 1,
+			history: [{ role: "user", content: "hi" }],
+		};
+		const steps: IterationStep[] = [];
+		for await (const step of driver(req, new AbortController().signal)) {
+			steps.push(step);
+		}
+		assert.equal(steps.length, 1);
+		assert.equal(steps[0]?.kind, "error");
+		assert.match(
+			(steps[0] as { error: Error }).error.message,
+			/empty response/,
+		);
+	});
+});
+
+describe("rlmDriver + runAgent — full wiring (hermetic)", () => {
+	it("drives runAgent to a clean complete with event flow", async () => {
+		const { fn, seen } = fakeLLM("42");
+		const driver = rlmDriver({
+			model: MODEL,
+			system: "Return just a number.",
+			llm: fn,
+		});
+		const events = await drain(
+			runAgent({
+				agentId: "test",
+				sessionId: "s-rlm-smoke",
+				input: "what is the answer?",
+				driver,
+				maxIterations: 3,
+			}),
+		);
+		const types = events.map((e) => e.type);
+		assert.equal(types[0], "AgentStart");
+		assert.ok(types.includes("IterationStart"));
+		assert.ok(types.includes("Message"));
+		assert.ok(types.includes("EmitDone"));
+		assert.equal(types[types.length - 1], "SessionClose");
+		const close = events.find((e) => e.type === "SessionClose") as
+			| { reason: string }
+			| undefined;
+		assert.equal(close?.reason, "complete");
+		// The LLM was called once and saw the system+user composition.
+		assert.equal(seen.prompts.length, 1);
+		assert.match(seen.prompts[0] ?? "", /Return just a number\./);
+		assert.match(seen.prompts[0] ?? "", /User: what is the answer\?/);
+	});
+
+	it("surfaces driver errors as Error{phase:driver} + SessionClose{error}", async () => {
+		const driver = rlmDriver({
+			model: MODEL,
+			llm: failingLLM(new Error("network down")),
+		});
+		const events = await drain(
+			runAgent({
+				agentId: "test",
+				sessionId: "s-rlm-err",
+				input: "hi",
+				driver,
+				maxIterations: 1,
+			}),
+		);
+		const err = events.find(
+			(e) =>
+				e.type === "Error" &&
+				(e as { phase: string }).phase === "driver",
+		);
+		assert.ok(err);
+		assert.match(
+			((err as { error: { message: string } }).error.message ?? "").toString(),
+			/network down/,
+		);
+		const close = events.find((e) => e.type === "SessionClose") as
+			| { reason: string }
+			| undefined;
+		assert.equal(close?.reason, "error");
+	});
+
+	it("retryHint from validate reaches the next prompt", async () => {
+		// First call returns a payload missing `answer`; second call returns
+		// one that passes. The driver must surface the retryHint from
+		// runAgent's validate pipeline into the second LLM prompt.
+		const prompts: string[] = [];
+		let callCount = 0;
+		const llm = async (p: string): Promise<LLMResponse> => {
+			prompts.push(p);
+			callCount++;
+			// Shape the response so `emit_done { answer: <text> }` matches the
+			// schema. First iteration returns an empty-sounding response that
+			// will FAIL the validate (answer too short); second wins.
+			return { text: callCount === 1 ? "no" : "yes", usage: createUsage() };
+		};
+		const driver = rlmDriver({ model: MODEL, llm });
+		const events = await drain(
+			runAgent({
+				agentId: "test",
+				sessionId: "s-retry",
+				input: "hi",
+				driver,
+				validateSchema: {
+					type: "object",
+					required: ["answer"],
+					properties: {
+						answer: { type: "string", enum: ["yes", "maybe"] },
+					},
+				},
+				validateSchemaSource: "{enum:[yes,maybe]}",
+				maxIterations: 3,
+			}),
+		);
+		const validations = events.filter((e) => e.type === "Validation") as Array<{
+			status: string;
+			attempt: number;
+		}>;
+		assert.equal(validations[0]?.status, "fail");
+		assert.equal(validations[1]?.status, "pass");
+		assert.equal(prompts.length, 2);
+		assert.match(prompts[1] ?? "", /Retry hint from the validator/);
+	});
+});
+
+// ─── Smoke test — skipped unless GEMINI_API_KEY is set ────────────
+// CI keeps hermetic. Operators can run it locally with a key to
+// exercise the live-LLM path end-to-end.
+const LIVE_API_KEY =
+	process.env.GEMINI_API_KEY ||
+	process.env.GOOGLE_API_KEY ||
+	process.env.ANTHROPIC_API_KEY;
+
+describe(
+	"rlmDriver + runAgent — LIVE LLM smoke (skip when no API key)",
+	{ skip: !LIVE_API_KEY },
+	() => {
+		it("completes a one-shot run against a real model (<= 10s, tiny budget)", async () => {
+			// Prefer Gemini if available (default for rlmx); else Anthropic.
+			const provider = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY
+				? "google"
+				: "anthropic";
+			const model =
+				provider === "google"
+					? "gemini-2.5-flash"
+					: "claude-haiku-4-5";
+
+			const driver = rlmDriver({
+				model: { provider, model },
+				system:
+					"You are a terse calculator. Respond with ONLY a single number, no words.",
+			});
+
+			const events = await drain(
+				runAgent({
+					agentId: "live-smoke",
+					sessionId: `live-${Date.now()}`,
+					input: "What is 17 + 25?",
+					driver,
+					maxIterations: 1,
+				}),
+			);
+
+			const types = events.map((e) => e.type);
+			// Every run must bracket with AgentStart + SessionClose.
+			assert.equal(types[0], "AgentStart");
+			assert.equal(types[types.length - 1], "SessionClose");
+			// A real LLM SHOULD respond; if the API flaked, surface that
+			// explicitly — we'd rather see a red test than a silent skip.
+			const close = events.find((e) => e.type === "SessionClose") as
+				| { reason: string }
+				| undefined;
+			if (close?.reason === "error") {
+				const err = events.find((e) => e.type === "Error") as
+					| { error: { message: string } }
+					| undefined;
+				assert.fail(
+					`live smoke failed: ${err?.error?.message ?? "<no error event>"}`,
+				);
+			}
+			assert.equal(close?.reason, "complete");
+			const emitDone = events.find((e) => e.type === "EmitDone") as
+				| { payload: { answer: string } }
+				| undefined;
+			assert.ok(emitDone, "EmitDone event must fire for a completed run");
+			assert.ok(
+				emitDone?.payload?.answer && emitDone.payload.answer.length > 0,
+				"live LLM must produce a non-empty answer",
+			);
+		});
+	},
+);


### PR DESCRIPTION
## Summary

Wraps rlmx's existing LLM backend (`llmCompleteSimple` from `src/llm.ts`) as an `IterationDriver` so `runAgent()` can drive a real LLM through the Wish B wiring (session, permissions, validate, events) end-to-end. **Proven against live Gemini in a dev smoke** (970 ms, `SessionClose{complete}`). Zero touch to `src/rlm.ts`; the existing CLI entry (`rlmLoop`) stays byte-for-byte unchanged.

Depends on: #64, #65, #66 (all merged).

## Design trade-off I committed to + why

I flagged the "literal wrap of `rlmLoop`" vs "adapter reusing `llm.ts`" question during ACK. Looked at `RLMResult` more closely — it exposes only `answer / references / usage / iterations / model / budgetHit`. **No per-iteration trajectory, no tool-call log, no intermediate messages.** A literal wrap would surface zero tool calls to the permission chain and zero retry opportunities to validate — defeating the "prove live wiring" goal of this slice.

Went with the adapter: new `src/sdk/rlm-driver.ts` that uses the same `llmCompleteSimple` transport `rlm.ts` calls. One LLM call per iteration, response yielded as `Message` + `emit_done`. rlm.ts stays completely untouched.

Tool-call parsing (Python code blocks + REPL exec) is explicitly deferred — that's the natural follow-up when G3's tool plugin loader lands.

## Change shape (3 files, +502/-0)

| file | purpose |
|---|---|
| `src/sdk/rlm-driver.ts` (new) | `rlmDriver(config)` + `formatRlmPrompt(config, req)` + `RlmDriverConfig`. Injectable `llm` hook defaults to the real `llmCompleteSimple`; tests pass a synchronous fake. |
| `tests/sdk-rlm-driver.test.ts` (new) | 11 hermetic tests + 1 env-gated live smoke. Suites: prompt synthesis / step shape / full wiring / live LLM. |
| `src/sdk/index.ts` | Re-export `rlmDriver` + `formatRlmPrompt` + `RlmDriverConfig`. |

## Verification

- `npm run check` → clean
- `npm run build` → ok
- `node --test dist/tests/sdk-rlm-driver.test.js` → **11 / 11 pass** (live smoke skipped when key unset)
- `node --test dist/tests/sdk-*.test.js` → **77 / 77 pass** across 16 suites
- `npm test` (full) → **282 / 282 pass** (was 271 post-G2b; +11 new, zero regression)
- **Live smoke with `GEMINI_API_KEY` set** → **PASS** in 970 ms; real `gemini-2.5-flash` response; `AgentStart → IterationStart → Message → EmitDone → SessionClose{complete}` sequence observed end-to-end.

## Test discipline notes

- CI stays hermetic. The live-LLM suite is `describe(..., { skip: !LIVE_API_KEY }, ...)` — skipped silently when no `GEMINI_API_KEY` / `GOOGLE_API_KEY` / `ANTHROPIC_API_KEY` in env.
- Live test runs ONE prompt ("What is 17 + 25?") against the cheapest flash model. Cost per CI run with a key set: a fraction of a cent.
- Live test fails loudly if the API returns an error — no silent swallow. We'd rather see red than miss a broken wire.

## Wish B foundation checkpoint

With this PR the Wish B foundation is **proven end-to-end against a real LLM**:

| slice | status |
|---|---|
| G1 events + emitter | ✅ #64 |
| G2 session/perm/validate primitives | ✅ #65 |
| G2b runAgent + wire | ✅ #66 |
| G2c live-LLM smoke | ← this PR |

Group 3 (tool plugin loader + RTK native + per-depth metrics) builds on a verified foundation.

## Scope boundary (out of this PR)

- Tool-call parsing from Python code blocks (needs REPL executor — G3 territory).
- `rlmLoop` replacement in the CLI (`rlmx "query"` still calls `rlmLoop`).
- pgserve-backed `SessionStore`.
- Per-depth metrics / token counting across recursion boundaries (G3).

## Base + head

- Base: `dev` @ `7803856`
- Head: `4e42805`
- Branch: `feat/rlm-driver-adapter`

## Next after merge

Per WISH.md order:
- **Group 3** — tool plugin loader + RTK native + per-depth metrics
- **Group 4** — documentation + example agents
- **Group 5** — genie RlmxExecutor (consumer side)

Your call on priority.