### PR TITLE
feat(sdk): tool loader + RTK native + per-depth metrics — Wish B G3a

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,11 +1,13 @@
-# rlmx SDK — Event Stream + Session / Permission / Validate primitives + runAgent
+# rlmx SDK — Events, runAgent, primitives, tool loader
 
-> **Status:** Wish B Groups 1 + 2 + 2b.
+> **Status:** Wish B Groups 1 + 2 + 2b + 2c + 3a.
 > G1 shipped event types + emitter.
 > G2 added session persistence, permission hooks, validate primitive, session-lifecycle events.
-> **G2b wires everything into `runAgent()`** — the pluggable driver seam lets consumers
-> plug in a canned driver (tests) or (later) `rlm.ts` (production). CLI entry
-> switch-over remains a separate slice.
+> G2b wired everything into `runAgent()` with a pluggable driver seam.
+> G2c proved the wiring against a live LLM via `rlmDriver`.
+> **G3a adds the tool plugin loader: `agent.yaml` spec parser, in-process
+> `ToolRegistry`, JS/MJS plugin resolution, RTK as a first-class tool,
+> and per-depth structured metrics riding on `IterationOutput.metrics`.**
 > See `.genie/wishes/rlmx-sdk-upgrade/WISH.md`.
 
 The SDK yields a stream of typed events describing one agent run.
@@ -159,15 +161,84 @@ boundaries; the emitter closes with `SessionClose { reason: "abort" }`
 and the snapshot is checkpointed so `resumeAgent(sessionId, store)`
 picks up where abort hit.
 
+## Tool plugin loader (Group 3a)
+
+```ts
+import { sdk } from "@automagik/rlmx";
+
+// 1. Load the agent's declared shape
+const spec = await sdk.loadAgentSpec("/path/to/my-agent");
+
+// 2. Register pre-built tools that ship with the SDK
+const registry = sdk.createToolRegistry();
+await sdk.registerRtkTool(registry); // no-op if rtk binary absent
+
+// 3. Fill in the rest from `tools/*.mjs` files next to agent.yaml
+const { loaded, skipped, missing } = await sdk.loadPluginTools(spec, registry);
+// loaded:  tools newly added from files
+// skipped: pre-registered (e.g. rtk) — file ignored
+// missing: declared in agent.yaml but no plugin file on disk
+
+// 4. Hand the registry to runAgent
+for await (const ev of sdk.runAgent({
+	agentId: "my-agent",
+	sessionId: "s-1",
+	input: "hello",
+	driver,                     // IterationDriver (canned or rlmDriver)
+	toolRegistry: registry,     // replaces `toolResolver`
+})) {
+	// ...
+}
+```
+
+### Plugin file shape (`tools/<name>.mjs` or `.js`)
+
+```js
+export default async function greet(args, ctx) {
+	// args  — the payload from an IterationStep `tool_call`
+	// ctx   — { tool, sessionId, iteration, signal }
+	return `hello ${args.name}`;
+}
+```
+
+Extension priority: `.mjs` → `.js`. TypeScript source loading lands in G3b
+when the Python plugin path also lands (shared concern: runtime loader).
+
+## Per-depth metrics (Group 3a)
+
+`IterationOutputEvent.metrics` is optional and present whenever runAgent
+is driving (i.e. always when you use `runAgent()`):
+
+```ts
+{
+	depth: 0,         // recursion depth this iteration ran at
+	parentDepth: -1,  // top-level convention
+	latencyMs: 742,
+	toolCalls: 3,     // includes denies
+	// Optional — consumer-supplied via MetricsRecorder inside the driver:
+	costUsd: 0.0012,
+	tokens: { input: 420, output: 58, cached: 12 },
+	cacheHitRatio: 0.3,
+}
+```
+
+Pass `{ depth, parentDepth }` on `AgentConfig` when driving nested `rlm_query`
+recursions so per-depth aggregation has the right context. The driver can
+inject cost/tokens/cache via a `MetricsRecorder` passed through `metricsRecorder`
+on `AgentConfig`.
+
 ## Scope boundary
 
 These PRs ship contract shape + emit infrastructure + Group-2
-primitives + the `runAgent()` wire (G2b).
-They do **not**:
+primitives + the `runAgent()` wire (G2b) + the tool plugin loader /
+RTK / metrics (G3a). They do **not**:
 
 - instrument `rlm.ts` directly — the iteration logic is behind the
   `IterationDriver` seam, so `rlm.ts` remains untouched until a
   cutover slice wraps it as a driver;
 - switch the CLI to use `runAgent()` — `rlmx "query"` still drives
   `rlmLoop` as before;
+- load `.ts`-source plugins — only pre-compiled `.mjs` / `.js`
+  (the shared-runtime concern with Python loading lands in G3b);
+- load Python plugins (G3b);
 - ship a pgserve-backed `SessionStore` implementation.

--- a/src/sdk/agent-spec.ts
+++ b/src/sdk/agent-spec.ts
@@ -1,0 +1,182 @@
+/**
+ * `agent.yaml` parser — Wish B Group 3.
+ *
+ * Minimal schema matching the folder-based agent convention from
+ * wish A (khal-os/brain `.agents/<name>/agent.yaml`). Only the fields
+ * the SDK needs for plugin loading + runAgent wiring are parsed here;
+ * extra YAML keys are preserved on the returned `extras` bag so
+ * consumers can layer their own schema on top without forking this
+ * parser.
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L24, L164-168.
+ */
+
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import yaml from "js-yaml";
+
+export interface AgentBudget {
+	readonly maxCost?: number;
+	readonly maxIterations?: number;
+	readonly maxDepth?: number;
+}
+
+export interface AgentScope {
+	readonly reads?: readonly string[];
+	readonly writes?: readonly string[];
+}
+
+export interface AgentSpec {
+	/** Agent directory on disk — parent of agent.yaml. All tool-file
+	 *  resolutions are relative to this path. */
+	readonly dir: string;
+	readonly schemaVersion: number;
+	readonly toolsApi: number;
+	readonly shape: "single-step" | "loop" | "recurse";
+	readonly model?: string;
+	readonly tools: readonly string[];
+	readonly systemPath?: string;
+	readonly scope?: AgentScope;
+	readonly budget?: AgentBudget;
+	/** Preserved unrecognised keys — consumers layer their own schema. */
+	readonly extras: Readonly<Record<string, unknown>>;
+}
+
+const VALID_SHAPES: readonly AgentSpec["shape"][] = [
+	"single-step",
+	"loop",
+	"recurse",
+] as const;
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asStringArray(value: unknown): readonly string[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const out: string[] = [];
+	for (const v of value) {
+		if (typeof v !== "string") continue;
+		if (v.length === 0) continue;
+		out.push(v);
+	}
+	return out;
+}
+
+function parseBudget(raw: unknown): AgentBudget | undefined {
+	if (!raw || typeof raw !== "object") return undefined;
+	const b = raw as Record<string, unknown>;
+	const out: AgentBudget = {
+		maxCost: asNumber(b.max_cost ?? b.maxCost),
+		maxIterations: asNumber(b.max_iterations ?? b.maxIterations),
+		maxDepth: asNumber(b.max_depth ?? b.maxDepth),
+	};
+	if (
+		out.maxCost === undefined &&
+		out.maxIterations === undefined &&
+		out.maxDepth === undefined
+	) {
+		return undefined;
+	}
+	return out;
+}
+
+function parseScope(raw: unknown): AgentScope | undefined {
+	if (!raw || typeof raw !== "object") return undefined;
+	const s = raw as Record<string, unknown>;
+	const reads = asStringArray(s.reads);
+	const writes = asStringArray(s.writes);
+	if (!reads && !writes) return undefined;
+	return { reads, writes };
+}
+
+/**
+ * Parse a raw YAML string into an `AgentSpec`. `dir` is the agent's
+ * filesystem directory — used later by the tool loader to resolve
+ * plugin file paths. Throws on schema violations with a precise
+ * message identifying the offending key.
+ */
+export function parseAgentSpec(yamlText: string, dir: string): AgentSpec {
+	let raw: unknown;
+	try {
+		raw = yaml.load(yamlText);
+	} catch (err) {
+		throw new Error(
+			`agent.yaml: parse error: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+		throw new Error("agent.yaml: expected a YAML mapping at the top level");
+	}
+	const r = raw as Record<string, unknown>;
+
+	const schemaVersion = asNumber(r.schema_version ?? r.schemaVersion) ?? 1;
+	const toolsApi = asNumber(r.tools_api ?? r.toolsApi) ?? 1;
+
+	const shapeRaw = asString(r.shape) ?? "single-step";
+	if (!VALID_SHAPES.includes(shapeRaw as AgentSpec["shape"])) {
+		throw new Error(
+			`agent.yaml: shape must be one of ${VALID_SHAPES.join(" | ")}, got "${shapeRaw}"`,
+		);
+	}
+
+	const tools = asStringArray(r.tools) ?? [];
+
+	const systemPath = asString(r.system);
+
+	// Build the "extras" bag by stripping the known keys from r.
+	const known = new Set([
+		"schema_version",
+		"schemaVersion",
+		"tools_api",
+		"toolsApi",
+		"shape",
+		"model",
+		"tools",
+		"system",
+		"scope",
+		"budget",
+	]);
+	const extras: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(r)) {
+		if (!known.has(k)) extras[k] = v;
+	}
+
+	return {
+		dir,
+		schemaVersion,
+		toolsApi,
+		shape: shapeRaw as AgentSpec["shape"],
+		model: asString(r.model),
+		tools,
+		systemPath,
+		scope: parseScope(r.scope),
+		budget: parseBudget(r.budget),
+		extras,
+	};
+}
+
+/**
+ * Load + parse an agent directory's `agent.yaml`. Convenience wrapper
+ * around `readFile` + `parseAgentSpec`. The returned `AgentSpec.dir`
+ * is the absolute path of the supplied `agentDir` so downstream
+ * plugin-path resolution has an anchor regardless of cwd.
+ */
+export async function loadAgentSpec(agentDir: string): Promise<AgentSpec> {
+	const abs = isAbsolute(agentDir) ? agentDir : resolve(agentDir);
+	const text = await readFile(join(abs, "agent.yaml"), "utf8");
+	return parseAgentSpec(text, abs);
+}
+
+/**
+ * Resolve an agent-relative path to an absolute path. Exported so the
+ * tool loader + consumers share a single resolution convention.
+ */
+export function resolveAgentPath(spec: AgentSpec, relative: string): string {
+	if (isAbsolute(relative)) return relative;
+	return resolve(dirname(join(spec.dir, "_")), relative);
+}

--- a/src/sdk/agent.ts
+++ b/src/sdk/agent.ts
@@ -35,6 +35,8 @@
  */
 
 import { createEmitter, type EventStream } from "./emitter.js";
+import { createMetricsRecorder, type MetricsRecorder } from "./metrics.js";
+import type { ToolRegistry } from "./tool-registry.js";
 import {
 	type AgentStartEvent,
 	type EmitDoneEvent,
@@ -117,6 +119,15 @@ export interface AgentConfig {
 
 	readonly driver: IterationDriver;
 	readonly toolResolver?: ToolResolver;
+	/**
+	 * Tool registry (Wish B G3a). When supplied, tool-call dispatch
+	 * prefers the registry: each `tool_call` step looks up `tool` in
+	 * the registry and invokes the handler. Missing handlers surface
+	 * as `Error{phase:"tool"}`. Takes precedence over `toolResolver`
+	 * when both are set; the resolver acts as a fallback for names
+	 * the registry doesn't know about.
+	 */
+	readonly toolRegistry?: ToolRegistry;
 
 	readonly sessionStore?: SessionStore;
 	readonly permissionHooks?: readonly PermissionHook[];
@@ -131,6 +142,18 @@ export interface AgentConfig {
 
 	/** Opaque snapshot attached to the AgentStart event for consumers. */
 	readonly configSnapshot?: Readonly<Record<string, unknown>>;
+
+	/**
+	 * Recursion depth this run is executing at. Top-level is 0. A
+	 * consumer driving nested `rlm_query` recursion should pass the
+	 * parent's depth + 1 so per-depth metrics carry the correct
+	 * context (Wish B G3).
+	 */
+	readonly depth?: number;
+	/** Parent depth for the per-depth metrics. Default -1 (top-level). */
+	readonly parentDepth?: number;
+	/** Custom recorder — when omitted, runAgent creates one per run. */
+	readonly metricsRecorder?: MetricsRecorder;
 }
 
 const DEFAULT_MAX_ITERATIONS = 32;
@@ -177,6 +200,7 @@ async function drive(
 		input,
 		driver,
 		toolResolver,
+		toolRegistry,
 		sessionStore,
 		permissionHooks = [],
 		validateSchema,
@@ -185,7 +209,35 @@ async function drive(
 		maxIterations = DEFAULT_MAX_ITERATIONS,
 		signal,
 		configSnapshot = {},
+		depth = 0,
+		parentDepth = -1,
+		metricsRecorder = createMetricsRecorder(),
 	} = config;
+
+	/**
+	 * Resolve a tool call via the registry first, the resolver second.
+	 * Throws when neither knows the tool so the error plumbing fires a
+	 * `ToolCallAfter{ok:false}` + `Error{phase:"tool"}` pair.
+	 */
+	async function dispatchTool(
+		tool: string,
+		args: unknown,
+		sig: AbortSignal,
+	): Promise<unknown> {
+		const handler = toolRegistry?.get(tool);
+		if (handler) {
+			return handler(args, {
+				tool,
+				sessionId,
+				iteration: currentIteration,
+				signal: sig,
+			});
+		}
+		if (toolResolver) return toolResolver(tool, args, sig);
+		throw new Error(`unknown tool: "${tool}" (no registry/resolver match)`);
+	}
+
+	let currentIteration = 0; // captured by dispatchTool for ctx.iteration
 
 	// ── emit AgentStart ──────────────────────────────────────────────
 	const startEv: AgentStartEvent = makeEvent("AgentStart", {
@@ -228,6 +280,8 @@ async function drive(
 	try {
 		iterationLoop: while (!done && iteration < maxIterations && !ac.signal.aborted) {
 			iteration++;
+			currentIteration = iteration;
+			metricsRecorder.start(depth, parentDepth);
 			const iterStart: IterationStartEvent = makeEvent("IterationStart", {
 				sessionId,
 				iteration,
@@ -279,6 +333,10 @@ async function drive(
 							args: effectiveArgs,
 						} as Omit<ToolCallBeforeEvent, "type" | "timestamp">);
 						em.emit(before);
+						// Count every attempted tool call, including denies — the
+						// metric answers "how many times did the agent TRY to call
+						// a tool this iteration", which denies are a signal for.
+						metricsRecorder.incrToolCalls();
 
 						if (decision.decision === "deny") {
 							const afterDeny: ToolCallAfterEvent = makeEvent(
@@ -309,8 +367,8 @@ async function drive(
 						let result: unknown = null;
 						let ok = true;
 						try {
-							if (toolResolver) {
-								result = await toolResolver(
+							if (toolRegistry || toolResolver) {
+								result = await dispatchTool(
 									step.tool,
 									effectiveArgs,
 									ac.signal,
@@ -424,6 +482,7 @@ async function drive(
 				sessionId,
 				iteration,
 				output: iterOutput,
+				metrics: metricsRecorder.snapshot(),
 			} as Omit<IterationOutputEvent, "type" | "timestamp">);
 			em.emit(out);
 

--- a/src/sdk/events.ts
+++ b/src/sdk/events.ts
@@ -53,6 +53,26 @@ export interface IterationOutputEvent extends BaseEvent {
 	readonly sessionId: string;
 	readonly iteration: number;
 	readonly output: string;
+	/**
+	 * Per-iteration structured metrics (Wish B G3). Optional — present
+	 * when runAgent (or a consumer wrapper) wires a `MetricsRecorder`.
+	 * See `metrics.ts` for the shape. Keeps `ALL_AGENT_EVENT_TYPES`
+	 * pinned at 12 by riding on an existing event instead of adding
+	 * a new `MetricEvent` variant.
+	 */
+	readonly metrics?: {
+		readonly depth: number;
+		readonly parentDepth: number;
+		readonly latencyMs: number;
+		readonly toolCalls: number;
+		readonly costUsd?: number;
+		readonly tokens?: {
+			readonly input: number;
+			readonly output: number;
+			readonly cached?: number;
+		};
+		readonly cacheHitRatio?: number;
+	};
 }
 
 export interface ToolCallBeforeEvent extends BaseEvent {

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -86,3 +86,35 @@ export type {
 // ─── rlmDriver (G2c — real LLM bridge) ───────────────────────────
 export { formatRlmPrompt, rlmDriver } from "./rlm-driver.js";
 export type { RlmDriverConfig } from "./rlm-driver.js";
+
+// ─── Agent spec + tool plugin loader (G3a) ───────────────────────
+export {
+	loadAgentSpec,
+	parseAgentSpec,
+	resolveAgentPath,
+} from "./agent-spec.js";
+export type { AgentBudget, AgentScope, AgentSpec } from "./agent-spec.js";
+export {
+	createToolRegistry,
+	toolRegistryAsResolver,
+	UnknownToolError,
+} from "./tool-registry.js";
+export type { ToolContext, ToolHandler, ToolRegistry } from "./tool-registry.js";
+export {
+	InvalidPluginError,
+	MissingPluginError,
+	loadPluginTools,
+} from "./tool-loader.js";
+export type { LoadOptions, LoadResult } from "./tool-loader.js";
+
+// ─── RTK plugin (G3a) ────────────────────────────────────────────
+export { registerRtkTool } from "./rtk-plugin.js";
+export type {
+	RegisterRtkOptions,
+	RtkToolArgs,
+	RtkToolResult,
+} from "./rtk-plugin.js";
+
+// ─── Metrics (G3a) ───────────────────────────────────────────────
+export { createMetricsRecorder } from "./metrics.js";
+export type { IterationMetrics, MetricsRecorder } from "./metrics.js";

--- a/src/sdk/metrics.ts
+++ b/src/sdk/metrics.ts
@@ -1,0 +1,116 @@
+/**
+ * Per-depth metrics — Wish B Group 3a.
+ *
+ * Ship-shape the "per-depth structured metrics JSON" WISH.md L26
+ * calls for. The actual emission rides on `IterationOutputEvent.metrics`
+ * (see `events.ts`) — this module supplies the type + a lightweight
+ * recorder that tracks latency / tool call count / token deltas across
+ * an iteration so runAgent can hand a final payload to the event
+ * without every call site needing to re-derive it.
+ *
+ * Cost + cache-hit metrics are consumer-supplied: if the driver knows
+ * the token cost it returns it on its `emit_done` step (or via a
+ * future per-iteration usage hook). For now the built-in recorder
+ * tracks the deterministic pieces (latency, tool-call count, depth)
+ * and lets consumers pipe in cost/tokens via `addCost` / `addTokens`.
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L26, L169.
+ */
+
+export interface IterationMetrics {
+	/** Recursion depth at which this iteration ran. 0 for top-level. */
+	readonly depth: number;
+	/** Parent depth — top-level has parentDepth=-1 by convention. */
+	readonly parentDepth: number;
+	/** Iteration wall-clock latency in milliseconds. */
+	readonly latencyMs: number;
+	/** Total tool calls issued during this iteration (incl. denies). */
+	readonly toolCalls: number;
+	/** Optional — cost in USD accumulated this iteration. */
+	readonly costUsd?: number;
+	/** Optional — token tally (input / output / cached). */
+	readonly tokens?: {
+		readonly input: number;
+		readonly output: number;
+		readonly cached?: number;
+	};
+	/** Optional — cache hit ratio in [0, 1]. Consumer-supplied. */
+	readonly cacheHitRatio?: number;
+}
+
+export interface MetricsRecorder {
+	/** Mark the start of an iteration — resets latency baseline. */
+	start(depth: number, parentDepth: number): void;
+	incrToolCalls(): void;
+	addCost(usd: number): void;
+	addTokens(input: number, output: number, cached?: number): void;
+	setCacheHitRatio(ratio: number): void;
+	/** Freeze the recorder's current state as a plain object. Safe to
+	 *  emit on events; returns a fresh snapshot each call. */
+	snapshot(): IterationMetrics;
+}
+
+export function createMetricsRecorder(): MetricsRecorder {
+	let depth = 0;
+	let parentDepth = -1;
+	let t0 = Date.now();
+	let toolCalls = 0;
+	let costUsd: number | undefined;
+	let inputTokens: number | undefined;
+	let outputTokens: number | undefined;
+	let cachedTokens: number | undefined;
+	let cacheHitRatio: number | undefined;
+
+	return {
+		start(d, p) {
+			depth = d;
+			parentDepth = p;
+			t0 = Date.now();
+			toolCalls = 0;
+			costUsd = undefined;
+			inputTokens = undefined;
+			outputTokens = undefined;
+			cachedTokens = undefined;
+			cacheHitRatio = undefined;
+		},
+		incrToolCalls() {
+			toolCalls++;
+		},
+		addCost(usd) {
+			if (!Number.isFinite(usd)) return;
+			costUsd = (costUsd ?? 0) + usd;
+		},
+		addTokens(input, output, cached) {
+			inputTokens = (inputTokens ?? 0) + (Number.isFinite(input) ? input : 0);
+			outputTokens = (outputTokens ?? 0) + (Number.isFinite(output) ? output : 0);
+			if (cached !== undefined && Number.isFinite(cached)) {
+				cachedTokens = (cachedTokens ?? 0) + cached;
+			}
+		},
+		setCacheHitRatio(ratio) {
+			if (!Number.isFinite(ratio)) return;
+			cacheHitRatio = Math.max(0, Math.min(1, ratio));
+		},
+		snapshot(): IterationMetrics {
+			const tokens =
+				inputTokens !== undefined || outputTokens !== undefined
+					? {
+							input: inputTokens ?? 0,
+							output: outputTokens ?? 0,
+							...(cachedTokens !== undefined
+								? { cached: cachedTokens }
+								: {}),
+						}
+					: undefined;
+			return {
+				depth,
+				parentDepth,
+				latencyMs: Date.now() - t0,
+				toolCalls,
+				...(costUsd !== undefined ? { costUsd } : {}),
+				...(tokens ? { tokens } : {}),
+				...(cacheHitRatio !== undefined ? { cacheHitRatio } : {}),
+			};
+		},
+	};
+}

--- a/src/sdk/rtk-plugin.ts
+++ b/src/sdk/rtk-plugin.ts
@@ -1,0 +1,134 @@
+/**
+ * RTK tool plugin — Wish B Group 3a.
+ *
+ * Exposes `rtk` (Rust Token Killer) as a first-class entry in the
+ * SDK tool registry. When the `rtk` binary is on PATH, the plugin
+ * shells out to it; otherwise the registration is a no-op and the
+ * registry never gains the tool. This mirrors the existing rlmx
+ * `rtk.enabled: auto` policy (`rlm.ts` + `rtk-detect.ts`): agents
+ * that declare `rtk` in `agent.yaml` get it for free on machines
+ * with rtk installed, and silently degrade on machines without.
+ *
+ * The plugin's handler signature:
+ *
+ *   args: { cmd: string[]; timeoutMs?: number }
+ *   returns: { stdout: string; stderr: string; exitCode: number; durationMs: number }
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L27 (RTK fully wired
+ * native, zero user config).
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { detectRtk } from "../rtk-detect.js";
+import type { ToolHandler, ToolRegistry } from "./tool-registry.js";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface RtkToolArgs {
+	readonly cmd: readonly string[];
+	readonly timeoutMs?: number;
+}
+
+export interface RtkToolResult {
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly exitCode: number;
+	readonly durationMs: number;
+}
+
+export interface RegisterRtkOptions {
+	/** Override the tool name. Default: `"rtk"`. Use a distinct name
+	 *  if your agent needs two RTK-flavoured tools (e.g. one sandboxed
+	 *  + one raw) and you want both in the same registry. */
+	readonly name?: string;
+	/** When true, the registry always gains the tool even if
+	 *  `rtk-detect` says RTK is unavailable. The handler then fails at
+	 *  call time. Default: false (only register when detected). */
+	readonly forceRegister?: boolean;
+}
+
+/**
+ * Validate the args shape at call time — the SDK's ToolResolver hands
+ * us `unknown`, so we guard before spawning a subprocess.
+ */
+function validateArgs(raw: unknown): RtkToolArgs {
+	if (!raw || typeof raw !== "object") {
+		throw new TypeError("rtk: args must be an object");
+	}
+	const r = raw as Record<string, unknown>;
+	if (!Array.isArray(r.cmd) || r.cmd.length === 0) {
+		throw new TypeError("rtk: args.cmd must be a non-empty string array");
+	}
+	const cmd = r.cmd.filter((c): c is string => typeof c === "string");
+	if (cmd.length !== r.cmd.length) {
+		throw new TypeError("rtk: args.cmd must contain only strings");
+	}
+	const timeoutMs =
+		typeof r.timeoutMs === "number" && Number.isFinite(r.timeoutMs)
+			? r.timeoutMs
+			: undefined;
+	return { cmd, timeoutMs };
+}
+
+function makeRtkHandler(): ToolHandler {
+	return async (argsRaw, ctx) => {
+		const args = validateArgs(argsRaw);
+		const timeoutMs = args.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+		const t0 = Date.now();
+		const [bin, ...rest] = args.cmd;
+		// cmd[0] shadows the rtk binary on PATH — spawn it directly.
+		// This matches the "auto-prefix" behaviour rlmx's run_cli uses
+		// (cf. rlm.ts). Consumers that want literal `rtk <subcmd>`
+		// invocations should pass `cmd: ["rtk", ...]` explicitly.
+		try {
+			const { stdout, stderr } = await execFileAsync(bin ?? "rtk", rest, {
+				timeout: timeoutMs,
+				signal: ctx.signal,
+				maxBuffer: 4 * 1024 * 1024,
+			});
+			const result: RtkToolResult = {
+				stdout,
+				stderr,
+				exitCode: 0,
+				durationMs: Date.now() - t0,
+			};
+			return result;
+		} catch (err) {
+			if (err && typeof err === "object" && "code" in err) {
+				const e = err as NodeJS.ErrnoException & {
+					stdout?: string;
+					stderr?: string;
+				};
+				const code = typeof e.code === "number" ? e.code : 1;
+				return {
+					stdout: e.stdout ?? "",
+					stderr: e.stderr ?? e.message,
+					exitCode: code,
+					durationMs: Date.now() - t0,
+				} satisfies RtkToolResult;
+			}
+			throw err;
+		}
+	};
+}
+
+/**
+ * Register RTK as a first-class tool in `registry`. Returns `true`
+ * when the tool was registered, `false` when RTK isn't on PATH (and
+ * `forceRegister` wasn't set). Idempotent: a second call with RTK
+ * already present in the registry is a no-op.
+ */
+export async function registerRtkTool(
+	registry: ToolRegistry,
+	options: RegisterRtkOptions = {},
+): Promise<boolean> {
+	const name = options.name ?? "rtk";
+	if (registry.has(name)) return true;
+	const detected = await detectRtk();
+	if (!detected.available && !options.forceRegister) return false;
+	registry.register(name, makeRtkHandler());
+	return true;
+}

--- a/src/sdk/tool-loader.ts
+++ b/src/sdk/tool-loader.ts
@@ -1,0 +1,167 @@
+/**
+ * Plugin loader — Wish B Group 3a.
+ *
+ * Reads an `AgentSpec.tools[]` list and populates a `ToolRegistry` by
+ * dynamically importing each plugin file from `<agent-dir>/tools/`.
+ * TypeScript-source loading is deferred to G3b (needs a TS runtime
+ * like tsx when plugins haven't been pre-compiled). This PR supports
+ * the universally-portable extensions: `.mjs` and `.js`.
+ *
+ * Contract for a plugin file (`tools/<name>.js` or `.mjs`):
+ *
+ *   export default async function(args, ctx) { return result; }
+ *
+ * The default export must be a function satisfying `ToolHandler`.
+ * Named exports are ignored; the loader only looks at `module.default`.
+ *
+ * Resolution algorithm:
+ *   1. `<agentDir>/tools/<name>.mjs`  ← preferred (ESM, explicit)
+ *   2. `<agentDir>/tools/<name>.js`   ← fallback
+ *   3. Miss → `MissingPluginError` with every attempted path listed.
+ *
+ * Plugins that aren't listed in `AgentSpec.tools` are NEVER loaded, so
+ * a stray file under `tools/` can't sneak in. Conversely, tool names
+ * already present in the registry (e.g. RTK pre-registered at startup)
+ * are skipped silently — the agent.yaml declaration is a *request*,
+ * not an override.
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L24, L164-168.
+ */
+
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { AgentSpec } from "./agent-spec.js";
+import type { ToolHandler, ToolRegistry } from "./tool-registry.js";
+
+/** Extensions the loader will try, in priority order. */
+const PLUGIN_EXTENSIONS = [".mjs", ".js"] as const;
+
+export interface LoadResult {
+	/** Names that were newly added to the registry. */
+	readonly loaded: readonly string[];
+	/** Names already in the registry (pre-registered, e.g. RTK). */
+	readonly skipped: readonly string[];
+	/** Tool names missing a plugin file — a warning, not a fatal error. */
+	readonly missing: readonly string[];
+}
+
+export class MissingPluginError extends Error {
+	readonly toolName: string;
+	readonly triedPaths: readonly string[];
+	constructor(toolName: string, triedPaths: readonly string[]) {
+		super(
+			`plugin for tool "${toolName}" not found. Tried:\n  ${triedPaths.join("\n  ")}`,
+		);
+		this.name = "MissingPluginError";
+		this.toolName = toolName;
+		this.triedPaths = triedPaths;
+	}
+}
+
+export class InvalidPluginError extends Error {
+	readonly toolName: string;
+	readonly pluginPath: string;
+	constructor(toolName: string, pluginPath: string, reason: string) {
+		super(
+			`plugin "${toolName}" at ${pluginPath} is invalid: ${reason}`,
+		);
+		this.name = "InvalidPluginError";
+		this.toolName = toolName;
+		this.pluginPath = pluginPath;
+	}
+}
+
+async function fileExists(path: string): Promise<boolean> {
+	try {
+		const s = await stat(path);
+		return s.isFile();
+	} catch {
+		return false;
+	}
+}
+
+async function resolvePluginPath(
+	agentDir: string,
+	name: string,
+): Promise<{ path: string | null; tried: readonly string[] }> {
+	const tried: string[] = [];
+	for (const ext of PLUGIN_EXTENSIONS) {
+		const candidate = join(agentDir, "tools", `${name}${ext}`);
+		tried.push(candidate);
+		if (await fileExists(candidate)) return { path: candidate, tried };
+	}
+	return { path: null, tried };
+}
+
+function coerceDefaultExport(
+	mod: unknown,
+	toolName: string,
+	pluginPath: string,
+): ToolHandler {
+	if (!mod || typeof mod !== "object") {
+		throw new InvalidPluginError(
+			toolName,
+			pluginPath,
+			"module did not evaluate to an object",
+		);
+	}
+	const m = mod as Record<string, unknown>;
+	const handler = m.default;
+	if (typeof handler !== "function") {
+		throw new InvalidPluginError(
+			toolName,
+			pluginPath,
+			"missing default export (expected `export default async (args, ctx) => ...`)",
+		);
+	}
+	return handler as ToolHandler;
+}
+
+export interface LoadOptions {
+	/** When true, missing plugin files throw `MissingPluginError` instead
+	 *  of accumulating on `LoadResult.missing`. Default: false (non-fatal).
+	 *  Use `strict: true` for production startup to fail-fast on typos. */
+	readonly strict?: boolean;
+}
+
+/**
+ * Load every plugin listed in `spec.tools` into `registry`. Returns a
+ * breakdown of loaded / skipped / missing names so callers can log
+ * the outcome. Tool names already in the registry are skipped (not
+ * overridden) — pre-registered handlers (RTK, consumer-supplied)
+ * always win.
+ */
+export async function loadPluginTools(
+	spec: AgentSpec,
+	registry: ToolRegistry,
+	options: LoadOptions = {},
+): Promise<LoadResult> {
+	const loaded: string[] = [];
+	const skipped: string[] = [];
+	const missing: string[] = [];
+
+	for (const name of spec.tools) {
+		if (registry.has(name)) {
+			skipped.push(name);
+			continue;
+		}
+
+		const { path, tried } = await resolvePluginPath(spec.dir, name);
+		if (!path) {
+			if (options.strict) throw new MissingPluginError(name, tried);
+			missing.push(name);
+			continue;
+		}
+
+		// Use the file:// URL form — dynamic import() on a bare absolute
+		// path fails on Windows and in some Node configs. `pathToFileURL`
+		// handles both without surprises.
+		const mod = (await import(pathToFileURL(path).href)) as unknown;
+		const handler = coerceDefaultExport(mod, name, path);
+		registry.register(name, handler);
+		loaded.push(name);
+	}
+
+	return { loaded, skipped, missing };
+}

--- a/src/sdk/tool-registry.ts
+++ b/src/sdk/tool-registry.ts
@@ -1,0 +1,102 @@
+/**
+ * Tool registry — Wish B Group 3a.
+ *
+ * Maps tool names declared in `agent.yaml` (`tools: [...]`) to
+ * in-process handler functions the SDK can dispatch to. Both
+ * consumer-registered handlers (e.g. RTK plugin) and loader-registered
+ * handlers (TS plugins from `<agent-dir>/tools/<name>.ts`) land in
+ * the same registry.
+ *
+ * The registry is deliberately boring: `register`, `get`, `list`,
+ * `has`. Anything richer — permission overlays, timeouts, retries —
+ * belongs in the runAgent dispatch path, not here.
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L24, L164-168.
+ */
+
+import type { ToolResolver } from "./agent.js";
+
+export interface ToolContext {
+	readonly tool: string;
+	readonly sessionId: string;
+	readonly iteration: number;
+	readonly signal: AbortSignal;
+}
+
+export type ToolHandler = (
+	args: unknown,
+	ctx: ToolContext,
+) => Promise<unknown>;
+
+export interface ToolRegistry {
+	register(name: string, handler: ToolHandler): void;
+	get(name: string): ToolHandler | undefined;
+	has(name: string): boolean;
+	list(): readonly string[];
+	/** Replace the handler for a name if it exists; no-op otherwise. */
+	override(name: string, handler: ToolHandler): boolean;
+}
+
+export class UnknownToolError extends Error {
+	readonly toolName: string;
+	constructor(name: string) {
+		super(`unknown tool: "${name}" (registry has no handler)`);
+		this.name = "UnknownToolError";
+		this.toolName = name;
+	}
+}
+
+/** Create a fresh in-memory tool registry. Simple Map under the hood. */
+export function createToolRegistry(): ToolRegistry {
+	const handlers = new Map<string, ToolHandler>();
+	return {
+		register(name, handler) {
+			if (name.length === 0) {
+				throw new TypeError("tool registry: name must be non-empty");
+			}
+			handlers.set(name, handler);
+		},
+		get(name) {
+			return handlers.get(name);
+		},
+		has(name) {
+			return handlers.has(name);
+		},
+		list() {
+			return [...handlers.keys()];
+		},
+		override(name, handler) {
+			if (!handlers.has(name)) return false;
+			handlers.set(name, handler);
+			return true;
+		},
+	};
+}
+
+/**
+ * Adapt a `ToolRegistry` into the `ToolResolver` shape `runAgent`
+ * accepts. When the requested tool is missing, throws
+ * `UnknownToolError` so the wiring surfaces it as a
+ * `ToolCallAfter{ok:false}` + `Error{phase:"tool"}` pair (handled
+ * by the existing runAgent error plumbing — no new event needed).
+ */
+export function toolRegistryAsResolver(
+	registry: ToolRegistry,
+): ToolResolver {
+	return async (tool, args, signal) => {
+		const handler = registry.get(tool);
+		if (!handler) throw new UnknownToolError(tool);
+		return await handler(args, {
+			tool,
+			// sessionId + iteration come from the registry consumer; we
+			// don't have them here. The runAgent dispatch path already
+			// emits ToolCallBefore/After with those fields, so handlers
+			// can reference the event stream for correlation. When a
+			// handler genuinely needs session context, wire a closure
+			// during `register` or use the config snapshot.
+			sessionId: "",
+			iteration: 0,
+			signal,
+		});
+	};
+}

--- a/tests/sdk-agent-spec.test.ts
+++ b/tests/sdk-agent-spec.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { loadAgentSpec, parseAgentSpec } from "../src/sdk/index.js";
+
+describe("parseAgentSpec — agent.yaml parser (G3a)", () => {
+	const DIR = "/tmp/fake-agent";
+
+	it("parses the minimal wish-A shape (triage example)", () => {
+		const text = `
+schema_version: 1
+tools_api: 1
+shape: single-step
+model: gemini-3.1-flash-lite-preview
+tools:
+  - read
+  - emit_done
+scope:
+  reads:
+    - Conversas/*
+budget:
+  max_cost: 0.01
+  max_iterations: 5
+`;
+		const spec = parseAgentSpec(text, DIR);
+		assert.equal(spec.dir, DIR);
+		assert.equal(spec.schemaVersion, 1);
+		assert.equal(spec.toolsApi, 1);
+		assert.equal(spec.shape, "single-step");
+		assert.equal(spec.model, "gemini-3.1-flash-lite-preview");
+		assert.deepEqual([...spec.tools], ["read", "emit_done"]);
+		assert.deepEqual([...(spec.scope?.reads ?? [])], ["Conversas/*"]);
+		assert.equal(spec.budget?.maxCost, 0.01);
+		assert.equal(spec.budget?.maxIterations, 5);
+	});
+
+	it("defaults schema_version / tools_api / shape when absent", () => {
+		const text = `model: gemini-2.5-flash\n`;
+		const spec = parseAgentSpec(text, DIR);
+		assert.equal(spec.schemaVersion, 1);
+		assert.equal(spec.toolsApi, 1);
+		assert.equal(spec.shape, "single-step");
+	});
+
+	it("rejects invalid shape", () => {
+		const text = `shape: multi-step\n`;
+		assert.throws(() => parseAgentSpec(text, DIR), /shape must be one of/);
+	});
+
+	it("rejects non-mapping YAML", () => {
+		assert.throws(
+			() => parseAgentSpec("just a string\n", DIR),
+			/mapping at the top level/,
+		);
+		assert.throws(() => parseAgentSpec("- a\n- b\n", DIR), /mapping at the top level/);
+	});
+
+	it("ignores empty tool names in the list", () => {
+		const text = `tools:\n  - ok\n  - ""\n  - also-ok\n`;
+		const spec = parseAgentSpec(text, DIR);
+		assert.deepEqual([...spec.tools], ["ok", "also-ok"]);
+	});
+
+	it("preserves unrecognised keys in extras", () => {
+		const text = `model: x\ncustom_flag: true\nnested:\n  a: 1\n`;
+		const spec = parseAgentSpec(text, DIR);
+		assert.equal(spec.extras.custom_flag, true);
+		assert.deepEqual(spec.extras.nested, { a: 1 });
+	});
+
+	it("handles camelCase + snake_case equivalently for schema fields", () => {
+		const a = parseAgentSpec(
+			"schema_version: 2\ntools_api: 3\n",
+			DIR,
+		);
+		const b = parseAgentSpec(
+			"schemaVersion: 2\ntoolsApi: 3\n",
+			DIR,
+		);
+		assert.equal(a.schemaVersion, 2);
+		assert.equal(a.toolsApi, 3);
+		assert.equal(b.schemaVersion, 2);
+		assert.equal(b.toolsApi, 3);
+	});
+
+	it("returns undefined scope/budget when the sections are empty", () => {
+		const spec = parseAgentSpec("tools: []\n", DIR);
+		assert.equal(spec.scope, undefined);
+		assert.equal(spec.budget, undefined);
+	});
+});
+
+describe("loadAgentSpec — filesystem wrapper (G3a)", () => {
+	let dir = "";
+	before(async () => {
+		dir = await mkdtemp(join(tmpdir(), "agent-spec-"));
+	});
+	after(async () => {
+		if (dir) await rm(dir, { recursive: true, force: true });
+	});
+
+	it("reads agent.yaml from the given dir + resolves to absolute", async () => {
+		await writeFile(
+			join(dir, "agent.yaml"),
+			"model: gemini-2.5-flash\ntools: [a, b]\n",
+			"utf8",
+		);
+		const spec = await loadAgentSpec(dir);
+		assert.equal(spec.dir, dir);
+		assert.equal(spec.model, "gemini-2.5-flash");
+		assert.deepEqual([...spec.tools], ["a", "b"]);
+	});
+
+	it("throws a useful error when agent.yaml is missing", async () => {
+		const missing = join(dir, "no-such-sub");
+		await assert.rejects(loadAgentSpec(missing));
+	});
+});

--- a/tests/sdk-metrics.test.ts
+++ b/tests/sdk-metrics.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	type AgentEvent,
+	createEmitter,
+	createMetricsRecorder,
+	type IterationOutputEvent,
+	runAgent,
+	type IterationStep,
+} from "../src/sdk/index.js";
+
+describe("createMetricsRecorder — per-depth tally (G3a)", () => {
+	it("start resets latency baseline + counters", () => {
+		const r = createMetricsRecorder();
+		r.start(0, -1);
+		r.incrToolCalls();
+		r.incrToolCalls();
+		r.addCost(0.01);
+		const s1 = r.snapshot();
+		assert.equal(s1.depth, 0);
+		assert.equal(s1.parentDepth, -1);
+		assert.equal(s1.toolCalls, 2);
+		assert.equal(s1.costUsd, 0.01);
+		// Second iteration — start() should reset.
+		r.start(1, 0);
+		const s2 = r.snapshot();
+		assert.equal(s2.depth, 1);
+		assert.equal(s2.parentDepth, 0);
+		assert.equal(s2.toolCalls, 0);
+		assert.equal(s2.costUsd, undefined);
+	});
+
+	it("addTokens accumulates + preserves cached when supplied", () => {
+		const r = createMetricsRecorder();
+		r.start(0, -1);
+		r.addTokens(100, 50);
+		r.addTokens(10, 5, 8);
+		const s = r.snapshot();
+		assert.deepEqual(s.tokens, { input: 110, output: 55, cached: 8 });
+	});
+
+	it("clamps cacheHitRatio to [0, 1]", () => {
+		const r = createMetricsRecorder();
+		r.start(0, -1);
+		r.setCacheHitRatio(-0.3);
+		assert.equal(r.snapshot().cacheHitRatio, 0);
+		r.setCacheHitRatio(1.4);
+		assert.equal(r.snapshot().cacheHitRatio, 1);
+		r.setCacheHitRatio(0.7);
+		assert.equal(r.snapshot().cacheHitRatio, 0.7);
+	});
+
+	it("ignores non-finite numbers silently", () => {
+		const r = createMetricsRecorder();
+		r.start(0, -1);
+		r.addCost(Number.NaN);
+		r.setCacheHitRatio(Number.POSITIVE_INFINITY);
+		const s = r.snapshot();
+		assert.equal(s.costUsd, undefined);
+		assert.equal(s.cacheHitRatio, undefined);
+	});
+
+	it("snapshot returns a fresh object each call", () => {
+		const r = createMetricsRecorder();
+		r.start(0, -1);
+		const a = r.snapshot();
+		const b = r.snapshot();
+		assert.notEqual(a, b);
+		assert.deepEqual(a, b);
+	});
+});
+
+describe("runAgent — emits IterationOutput.metrics (G3a)", () => {
+	async function drain(stream: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+		const out: AgentEvent[] = [];
+		for await (const ev of stream) out.push(ev);
+		return out;
+	}
+
+	it("default run attaches depth / parentDepth / latencyMs / toolCalls", async () => {
+		const driver = async function* () {
+			yield { kind: "emit_done", payload: { ok: true } } as IterationStep;
+		};
+		const events = await drain(
+			runAgent({
+				agentId: "m",
+				sessionId: "s",
+				input: "go",
+				driver,
+			}),
+		);
+		const out = events.find(
+			(e) => e.type === "IterationOutput",
+		) as IterationOutputEvent | undefined;
+		assert.ok(out);
+		assert.ok(out?.metrics);
+		assert.equal(out?.metrics?.depth, 0);
+		assert.equal(out?.metrics?.parentDepth, -1);
+		assert.equal(typeof out?.metrics?.latencyMs, "number");
+		assert.equal(out?.metrics?.toolCalls, 0);
+	});
+
+	it("depth / parentDepth from config propagate to the metrics snapshot", async () => {
+		const driver = async function* () {
+			yield { kind: "emit_done", payload: {} } as IterationStep;
+		};
+		const events = await drain(
+			runAgent({
+				agentId: "m",
+				sessionId: "s",
+				input: "go",
+				driver,
+				depth: 2,
+				parentDepth: 1,
+			}),
+		);
+		const out = events.find(
+			(e) => e.type === "IterationOutput",
+		) as IterationOutputEvent | undefined;
+		assert.equal(out?.metrics?.depth, 2);
+		assert.equal(out?.metrics?.parentDepth, 1);
+	});
+
+	it("toolCalls counter increments with tool_call steps (incl. denies)", async () => {
+		const driver = async function* () {
+			yield { kind: "tool_call", tool: "a", args: {} } as IterationStep;
+			yield { kind: "tool_call", tool: "b", args: {} } as IterationStep;
+			yield { kind: "emit_done", payload: {} } as IterationStep;
+		};
+		const events = await drain(
+			runAgent({
+				agentId: "m",
+				sessionId: "s",
+				input: "go",
+				driver,
+				// Deny "a", allow "b" — both still increment the counter.
+				permissionHooks: [
+					(ctx) => (ctx.tool === "a"
+						? { decision: "deny", reason: "nope" }
+						: { decision: "allow" }),
+				],
+				toolResolver: async () => null,
+			}),
+		);
+		const out = events.find(
+			(e) => e.type === "IterationOutput",
+		) as IterationOutputEvent | undefined;
+		assert.equal(out?.metrics?.toolCalls, 2);
+	});
+
+	it("custom recorder can inject consumer-supplied cost + tokens", async () => {
+		const rec = createMetricsRecorder();
+		const driver = async function* () {
+			rec.addCost(0.0005);
+			rec.addTokens(42, 11);
+			yield { kind: "emit_done", payload: {} } as IterationStep;
+		};
+		const events = await drain(
+			runAgent({
+				agentId: "m",
+				sessionId: "s",
+				input: "go",
+				driver,
+				metricsRecorder: rec,
+			}),
+		);
+		const out = events.find(
+			(e) => e.type === "IterationOutput",
+		) as IterationOutputEvent | undefined;
+		assert.equal(out?.metrics?.costUsd, 0.0005);
+		assert.deepEqual(out?.metrics?.tokens, { input: 42, output: 11 });
+	});
+});
+
+// Silence unused-var warning for the imported createEmitter — it's re-exported
+// so this file also exercises the public index surface.
+void createEmitter;

--- a/tests/sdk-rtk-plugin.test.ts
+++ b/tests/sdk-rtk-plugin.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	createToolRegistry,
+	registerRtkTool,
+} from "../src/sdk/index.js";
+
+describe("registerRtkTool (G3a)", () => {
+	it("registers under the default `rtk` name when forceRegister=true", async () => {
+		const r = createToolRegistry();
+		const ok = await registerRtkTool(r, { forceRegister: true });
+		assert.equal(ok, true);
+		assert.equal(r.has("rtk"), true);
+	});
+
+	it("supports a custom tool name", async () => {
+		const r = createToolRegistry();
+		await registerRtkTool(r, { forceRegister: true, name: "rtk-sandboxed" });
+		assert.equal(r.has("rtk-sandboxed"), true);
+		assert.equal(r.has("rtk"), false);
+	});
+
+	it("is idempotent — second call is a no-op when already present", async () => {
+		const r = createToolRegistry();
+		const first: () => Promise<number> = async () => 1;
+		// Pre-register a sentinel handler so we can detect accidental overwrite.
+		r.register("rtk", first as unknown as Parameters<typeof r.register>[1]);
+		const ok = await registerRtkTool(r, { forceRegister: true });
+		assert.equal(ok, true);
+		// Handler should still be the sentinel (idempotent — no overwrite).
+		assert.equal(r.get("rtk"), first);
+	});
+
+	it("when forceRegister=false + rtk absent, the tool is NOT registered", async () => {
+		// We can't simulate "rtk absent" reliably without mocking detectRtk —
+		// so instead we exercise the return value signature: in an env
+		// without rtk on PATH, this call returns false and leaves the
+		// registry empty. On a machine WITH rtk installed, it returns true.
+		// The test asserts either outcome is internally consistent.
+		const r = createToolRegistry();
+		const result = await registerRtkTool(r, { forceRegister: false });
+		assert.equal(result, r.has("rtk"));
+	});
+
+	it("handler validates args and rejects malformed payloads", async () => {
+		const r = createToolRegistry();
+		await registerRtkTool(r, { forceRegister: true });
+		const handler = r.get("rtk")!;
+		const ctx = {
+			tool: "rtk",
+			sessionId: "s",
+			iteration: 1,
+			signal: new AbortController().signal,
+		};
+		await assert.rejects(handler(null, ctx), /args must be an object/);
+		await assert.rejects(handler({}, ctx), /cmd must be a non-empty string array/);
+		await assert.rejects(
+			handler({ cmd: [123] }, ctx),
+			/cmd must contain only strings/,
+		);
+	});
+});

--- a/tests/sdk-tool-loader.test.ts
+++ b/tests/sdk-tool-loader.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import {
+	type AgentSpec,
+	createToolRegistry,
+	InvalidPluginError,
+	loadPluginTools,
+	MissingPluginError,
+} from "../src/sdk/index.js";
+
+async function writePlugin(
+	dir: string,
+	name: string,
+	body: string,
+	ext = ".mjs",
+): Promise<string> {
+	const toolsDir = join(dir, "tools");
+	await mkdir(toolsDir, { recursive: true });
+	const file = join(toolsDir, `${name}${ext}`);
+	await writeFile(file, body, "utf8");
+	return file;
+}
+
+function specFor(dir: string, tools: string[]): AgentSpec {
+	return {
+		dir,
+		schemaVersion: 1,
+		toolsApi: 1,
+		shape: "single-step",
+		tools,
+		extras: {},
+	} as AgentSpec;
+}
+
+describe("loadPluginTools — TS plugin loader (G3a, .mjs/.js only)", () => {
+	let root = "";
+	before(async () => {
+		root = await mkdtemp(join(tmpdir(), "plugin-loader-"));
+	});
+	after(async () => {
+		if (root) await rm(root, { recursive: true, force: true });
+	});
+
+	it("loads a plugin's default export into the registry", async () => {
+		const agentDir = join(root, "load-default");
+		await writePlugin(
+			agentDir,
+			"greet",
+			`export default async (args) => "hello " + args.name;\n`,
+		);
+		const registry = createToolRegistry();
+		const result = await loadPluginTools(specFor(agentDir, ["greet"]), registry);
+		assert.deepEqual([...result.loaded], ["greet"]);
+		assert.equal(result.missing.length, 0);
+		const handler = registry.get("greet");
+		assert.ok(handler);
+		const out = await handler!({ name: "sté" }, {
+			tool: "greet",
+			sessionId: "s",
+			iteration: 1,
+			signal: new AbortController().signal,
+		});
+		assert.equal(out, "hello sté");
+	});
+
+	it("skips tools already present in the registry (pre-registered wins)", async () => {
+		const agentDir = join(root, "skip");
+		await writePlugin(agentDir, "rtk", `export default async () => "file";\n`);
+		const registry = createToolRegistry();
+		registry.register("rtk", async () => "pre-registered");
+		const result = await loadPluginTools(specFor(agentDir, ["rtk"]), registry);
+		assert.deepEqual([...result.skipped], ["rtk"]);
+		assert.deepEqual([...result.loaded], []);
+		assert.equal(await registry.get("rtk")!({}, {
+			tool: "rtk",
+			sessionId: "",
+			iteration: 0,
+			signal: new AbortController().signal,
+		}), "pre-registered");
+	});
+
+	it("tracks missing plugins on the result when non-strict (default)", async () => {
+		const agentDir = join(root, "missing");
+		await mkdir(join(agentDir, "tools"), { recursive: true });
+		const registry = createToolRegistry();
+		const result = await loadPluginTools(
+			specFor(agentDir, ["no_such_tool"]),
+			registry,
+		);
+		assert.deepEqual([...result.missing], ["no_such_tool"]);
+		assert.equal(result.loaded.length, 0);
+	});
+
+	it("throws MissingPluginError in strict mode", async () => {
+		const agentDir = join(root, "missing-strict");
+		await mkdir(join(agentDir, "tools"), { recursive: true });
+		const registry = createToolRegistry();
+		await assert.rejects(
+			loadPluginTools(specFor(agentDir, ["nope"]), registry, { strict: true }),
+			(err: unknown) => {
+				assert.ok(err instanceof MissingPluginError);
+				assert.equal((err as MissingPluginError).toolName, "nope");
+				return true;
+			},
+		);
+	});
+
+	it("throws InvalidPluginError when the default export is not a function", async () => {
+		const agentDir = join(root, "invalid");
+		await writePlugin(
+			agentDir,
+			"bad",
+			`export default "not a function";\n`,
+		);
+		const registry = createToolRegistry();
+		await assert.rejects(
+			loadPluginTools(specFor(agentDir, ["bad"]), registry),
+			(err: unknown) => {
+				assert.ok(err instanceof InvalidPluginError);
+				assert.equal((err as InvalidPluginError).toolName, "bad");
+				return true;
+			},
+		);
+	});
+
+	it("prefers .mjs over .js when both are present", async () => {
+		const agentDir = join(root, "ext-priority");
+		await writePlugin(
+			agentDir,
+			"both",
+			`export default async () => "mjs";\n`,
+			".mjs",
+		);
+		// .js file with deliberately different output
+		await writePlugin(
+			agentDir,
+			"both",
+			`export default async () => "js";\n`,
+			".js",
+		);
+		const registry = createToolRegistry();
+		await loadPluginTools(specFor(agentDir, ["both"]), registry);
+		const result = await registry.get("both")!({}, {
+			tool: "both",
+			sessionId: "",
+			iteration: 0,
+			signal: new AbortController().signal,
+		});
+		assert.equal(result, "mjs");
+	});
+
+	it("falls back to .js when .mjs missing", async () => {
+		const agentDir = join(root, "js-fallback");
+		await writePlugin(
+			agentDir,
+			"fallback",
+			`export default async () => "js-only";\n`,
+			".js",
+		);
+		const registry = createToolRegistry();
+		await loadPluginTools(specFor(agentDir, ["fallback"]), registry);
+		const result = await registry.get("fallback")!({}, {
+			tool: "fallback",
+			sessionId: "",
+			iteration: 0,
+			signal: new AbortController().signal,
+		});
+		assert.equal(result, "js-only");
+	});
+
+	it("loads multiple tools in declaration order + reports a breakdown", async () => {
+		const agentDir = join(root, "multi");
+		await writePlugin(agentDir, "a", `export default async () => "A";\n`);
+		await writePlugin(agentDir, "b", `export default async () => "B";\n`);
+		await writePlugin(agentDir, "c", `export default async () => "C";\n`);
+		const registry = createToolRegistry();
+		registry.register("b", async () => "pre-b"); // one pre-registered
+		const result = await loadPluginTools(
+			specFor(agentDir, ["a", "b", "c", "d"]),
+			registry,
+		);
+		assert.deepEqual([...result.loaded], ["a", "c"]);
+		assert.deepEqual([...result.skipped], ["b"]);
+		assert.deepEqual([...result.missing], ["d"]);
+	});
+});

--- a/tests/sdk-tool-registry.test.ts
+++ b/tests/sdk-tool-registry.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	createToolRegistry,
+	type ToolHandler,
+	toolRegistryAsResolver,
+	UnknownToolError,
+} from "../src/sdk/index.js";
+
+const ok: ToolHandler = async () => "ok";
+
+describe("createToolRegistry — registry contract (G3a)", () => {
+	it("register + get + has roundtrip", () => {
+		const r = createToolRegistry();
+		assert.equal(r.has("x"), false);
+		assert.equal(r.get("x"), undefined);
+		r.register("x", ok);
+		assert.equal(r.has("x"), true);
+		assert.equal(typeof r.get("x"), "function");
+	});
+
+	it("list reflects registration order", () => {
+		const r = createToolRegistry();
+		r.register("b", ok);
+		r.register("a", ok);
+		r.register("c", ok);
+		assert.deepEqual([...r.list()], ["b", "a", "c"]);
+	});
+
+	it("rejects empty tool names", () => {
+		const r = createToolRegistry();
+		assert.throws(() => r.register("", ok), /non-empty/);
+	});
+
+	it("register overrides an existing handler (same name)", () => {
+		const r = createToolRegistry();
+		const first: ToolHandler = async () => "first";
+		const second: ToolHandler = async () => "second";
+		r.register("dup", first);
+		r.register("dup", second);
+		assert.equal(r.get("dup"), second);
+	});
+
+	it("override only replaces when the name already exists", () => {
+		const r = createToolRegistry();
+		r.register("a", ok);
+		assert.equal(r.override("a", async () => "new"), true);
+		assert.equal(r.override("b", async () => "new"), false);
+		assert.equal(r.has("b"), false);
+	});
+});
+
+describe("toolRegistryAsResolver — shim to ToolResolver (G3a)", () => {
+	it("dispatches to the registered handler + passes args through", async () => {
+		const r = createToolRegistry();
+		const seen: unknown[] = [];
+		r.register("echo", async (args) => {
+			seen.push(args);
+			return args;
+		});
+		const resolver = toolRegistryAsResolver(r);
+		const result = await resolver("echo", { hi: 1 }, new AbortController().signal);
+		assert.deepEqual(result, { hi: 1 });
+		assert.deepEqual(seen[0], { hi: 1 });
+	});
+
+	it("throws UnknownToolError for missing tools", async () => {
+		const r = createToolRegistry();
+		const resolver = toolRegistryAsResolver(r);
+		await assert.rejects(
+			resolver("missing", {}, new AbortController().signal),
+			(err: unknown) => {
+				assert.ok(err instanceof UnknownToolError);
+				assert.equal((err as UnknownToolError).toolName, "missing");
+				return true;
+			},
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Three G3 subsystems in one cohesive slice under the additive discipline we've held since G1:

1. **Tool plugin loader** — parse `agent.yaml`, resolve `<agent-dir>/tools/<name>.mjs|.js`, register in an in-process `ToolRegistry`.
2. **RTK as a first-class tool** — `registerRtkTool(registry)` wraps the existing `rtk-detect.ts`; when RTK is on PATH the registry gains a `rtk` handler that spawns subprocesses with timeout + abort + typed result.
3. **Per-depth structured metrics** — `IterationOutputEvent.metrics` (optional field, no new event type). Tracks depth / parentDepth / latencyMs / toolCalls deterministically; cost / tokens / cacheHitRatio consumer-supplied via `MetricsRecorder`.

Python plugin loading is explicitly G3b — subprocess exec + stdin/stdout marshalling + timeout handling + sandboxing belong in their own review surface.

Depends on: #64, #65, #66, #67 (all merged).

## Change shape (14 files, +1519/-9)

| file | role |
|---|---|
| `src/sdk/agent-spec.ts` (new) | `AgentSpec` + `parseAgentSpec` + `loadAgentSpec`. Minimal schema matching wish-A folder convention; unknown keys preserved on `extras`. |
| `src/sdk/tool-registry.ts` (new) | `ToolRegistry` + map-backed `createToolRegistry` + `toolRegistryAsResolver` shim + `UnknownToolError`. |
| `src/sdk/tool-loader.ts` (new) | `loadPluginTools(spec, registry, opts?)` resolves `.mjs` > `.js`, dynamic-imports default export, reports loaded/skipped/missing breakdown. `MissingPluginError` + `InvalidPluginError`. |
| `src/sdk/rtk-plugin.ts` (new) | `registerRtkTool(registry, opts?)` — auto-register on PATH, handler validates args at call time, spawns via `execFile` with timeout + signal. |
| `src/sdk/metrics.ts` (new) | `IterationMetrics` type + `createMetricsRecorder`. |
| `src/sdk/events.ts` | `IterationOutputEvent.metrics?` field. **ALL_AGENT_EVENT_TYPES stays at 12** (no new event variant). **WISH_SPEC_EVENT_TYPES pinned at 10**. |
| `src/sdk/agent.ts` | `AgentConfig.toolRegistry` (precedence over `toolResolver`), `depth`/`parentDepth`/`metricsRecorder` config fields. Every `IterationOutput` now carries metrics via recorder. ToolCallBefore increments `toolCalls` (denies are counted — "how often agent attempted a tool" is the signal consumers need). |
| `src/sdk/index.ts` | Re-exports for the full G3a surface. |
| `docs/events.md` | Tool loader + metrics usage sections + updated scope boundary. |
| `tests/sdk-*.test.ts` (5 new) | 39 tests total. |

## Design decisions worth flagging

### 1. Metrics ride on `IterationOutput.metrics`, not a new event

Per Simone's G3 dispatch ("ALL_AGENT_EVENT_TYPES pode crescer se precisar... flag se adiciona 3+ novos"). Zero new event types. Consumers unfamiliar with metrics can ignore the field; the 12-type pinned contract is untouched.

### 2. Tool registry wins over file-loaded plugins

If a consumer pre-registers a tool (e.g. `registerRtkTool` at startup, or a custom handler for a protected name), `loadPluginTools` reports it on `result.skipped` and leaves the pre-registration intact. Safer default: consumers can't have a stray file under `tools/` silently override a carefully-configured handler.

### 3. `.mjs` > `.js` only in this PR

TypeScript source (`.ts`) loading needs a runtime TS loader (tsx, Node experimental), which is the same risk surface as Python subprocess handling. Bundling those into G3b keeps scope reviewable.

### 4. Denies count toward `toolCalls`

Metric semantics: "how many tool calls did the agent attempt this iteration?" Denies are signal — a denied tool call tells you about agent behaviour. If consumers prefer net-executed count, they can diff against Error events.

## Verification

- `npm run check` (`tsc --noEmit`) → clean
- `npm run build` → ok
- G3a tests isolated → **39 / 39 pass** across 8 suites (9 agent-spec + 7 tool-registry + 8 tool-loader + 10 metrics + 5 rtk-plugin)
- SDK all isolated → **116 / 116 pass** across 20 suites
- `npm test` (full) → **321 / 321 pass** (was 282 post-G2c; +39 new, zero regression)

## Closes WISH.md G3 acceptance criteria, partially

| criterion | status |
|---|---|
| `agent.yaml` with `tools: [...]` auto-loads | ✅ TS/MJS path; Python ⏳ G3b |
| RTK auto-detected + used | ✅ `registerRtkTool` + handler |
| Per-depth metrics JSON emitted | ✅ on `IterationOutput.metrics` |
| RTK `run_cli` auto-prefix inside rlm.ts | unrelated CLI path — existing `rtk-detect` wiring, not the SDK tool registry |

## Scope boundary (out of this PR)

- Python plugin loading (subprocess exec + JSON marshalling — G3b)
- `.ts` source plugins (shared-runtime concern with G3b)
- Wiring the tool registry into the rlmx CLI's rlmLoop (separate cutover)
- pgserve-backed `SessionStore`

## Base + head

- Base: `dev` @ `aa61690`
- Head: `2a82cb8`
- Branch: `feat/tool-loader-rtk-metrics`

## Next after merge

- **G3b**: Python plugin loader (the distinct risk surface).
- **G4**: documentation pass + 3 example agents (WISH.md).
- **G5**: genie `RlmxExecutor` (consumer side, touches genie repo).

Your call on priority.