### PR TITLE
feat(sdk): Python plugin loader — Wish B G3b

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -201,8 +201,42 @@ export default async function greet(args, ctx) {
 }
 ```
 
-Extension priority: `.mjs` → `.js`. TypeScript source loading lands in G3b
-when the Python plugin path also lands (shared concern: runtime loader).
+Extension priority: `.mjs` → `.js` → `.py` (the last via `loadPythonPlugins`).
+TypeScript source loading is still deferred — needs a runtime TS loader
+(tsx or node --experimental-strip-types) and can land alongside G4 docs.
+
+### Python plugins (Group 3b)
+
+```python
+#!/usr/bin/env python3
+import json, sys
+args = json.load(sys.stdin)
+# ... tool logic ...
+json.dump({"ok": True, "value": args["x"] * 2}, sys.stdout)
+```
+
+```ts
+// Compose both loaders — JS/MJS first, Python for the remainder.
+const js = await sdk.loadPluginTools(spec, registry);
+const py = await sdk.loadPythonPlugins(spec, registry, {
+	timeoutMs: 30_000,
+	env: { PATH: process.env.PATH!, BRAIN_HOME: agentHome },
+});
+```
+
+Each Python call spawns a fresh subprocess (no REPL pooling), passes
+the `args` JSON on stdin, expects a JSON document on stdout, and captures
+stderr as diagnostic. Errors map to typed exceptions:
+
+| condition | error |
+|---|---|
+| wall-clock overrun | `PythonPluginTimeoutError` |
+| non-zero exit | `PythonPluginError` (exposes `exitCode`, `stderr`, `stdout`) |
+| malformed stdout JSON | `PythonPluginError` with message "stdout was not valid JSON" |
+| interpreter not found | `PythonPluginError` with "spawn failed: ..." |
+
+Out of scope today: heavy sandboxing (seccomp / namespaces), virtualenv
+management, streaming partial results, cross-language tool composition.
 
 ## Per-depth metrics (Group 3a)
 
@@ -239,6 +273,5 @@ RTK / metrics (G3a). They do **not**:
 - switch the CLI to use `runAgent()` — `rlmx "query"` still drives
   `rlmLoop` as before;
 - load `.ts`-source plugins — only pre-compiled `.mjs` / `.js`
-  (the shared-runtime concern with Python loading lands in G3b);
-- load Python plugins (G3b);
+  (TypeScript source still needs a runtime TS loader);
 - ship a pgserve-backed `SessionStore` implementation.

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -115,6 +115,21 @@ export type {
 	RtkToolResult,
 } from "./rtk-plugin.js";
 
+// ─── Python plugin loader (G3b) ──────────────────────────────────
+export {
+	DEFAULT_PYTHON_BIN,
+	DEFAULT_TIMEOUT_MS as PYTHON_DEFAULT_TIMEOUT_MS,
+	loadPythonPlugins,
+	makePythonPluginHandler,
+	PythonPluginError,
+	PythonPluginTimeoutError,
+} from "./python-plugin.js";
+export type {
+	PythonLoadResult,
+	PythonPluginExecResult,
+	PythonPluginOptions,
+} from "./python-plugin.js";
+
 // ─── Metrics (G3a) ───────────────────────────────────────────────
 export { createMetricsRecorder } from "./metrics.js";
 export type { IterationMetrics, MetricsRecorder } from "./metrics.js";

--- a/src/sdk/python-plugin.ts
+++ b/src/sdk/python-plugin.ts
@@ -1,0 +1,331 @@
+/**
+ * Python plugin loader — Wish B Group 3b.
+ *
+ * Extends the G3a tool plugin loader to accept `.py` files under
+ * `<agent-dir>/tools/<name>.py`. A Python plugin is a standalone
+ * script the SDK spawns once per tool call:
+ *
+ *   SDK → spawn(`python3 <plugin.py>`, stdin=JSON args)
+ *         → stdout: JSON result
+ *         → stderr: diagnostic text (captured, never interpreted)
+ *         → exit code: 0 pass, non-zero fail
+ *
+ * Plugin author contract (minimal, no framework lock-in):
+ *
+ *   #!/usr/bin/env python3
+ *   import json, sys
+ *   args = json.load(sys.stdin)
+ *   # ... user logic ...
+ *   json.dump(result, sys.stdout)
+ *
+ * Errors are surfaced via typed exceptions so the runAgent wiring
+ * classifies them correctly:
+ *
+ *   InvalidPluginError — plugin script unreadable / interpreter missing
+ *   PythonPluginTimeoutError — wall-clock budget exceeded
+ *   PythonPluginError — non-zero exit or malformed stdout JSON
+ *
+ * Out of scope (deferred):
+ *   - Heavy sandboxing (seccomp, namespaces, resource limits)
+ *   - Virtualenv / dependency management
+ *   - Streaming output / partial results
+ *   - Cross-language tool composition
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L24, L164-168 +
+ * G3b dispatch from simone.
+ */
+
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { AgentSpec } from "./agent-spec.js";
+import type { ToolHandler, ToolRegistry } from "./tool-registry.js";
+
+export const DEFAULT_PYTHON_BIN = "python3";
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
+export interface PythonPluginOptions {
+	/** Interpreter to spawn. Default `python3`; override for venv paths. */
+	readonly pythonBin?: string;
+	/** Per-call timeout. Default 30 s. Set to `null` to disable. */
+	readonly timeoutMs?: number | null;
+	/** Environment variables passed to the subprocess. When omitted the
+	 *  inherited `process.env` is forwarded unchanged so plugins can
+	 *  read the usual credentials. Pass `{}` to isolate (no env). */
+	readonly env?: Readonly<Record<string, string>>;
+	/** Working directory for the subprocess. Defaults to the agent
+	 *  directory — keeps `pathlib.Path.cwd()` lined up with
+	 *  `BRAIN_HOME`-style conventions. */
+	readonly cwd?: string;
+	/** When true, loadPythonPlugins throws `InvalidPluginError` if the
+	 *  interpreter binary cannot be resolved. Default false. */
+	readonly strictInterpreter?: boolean;
+}
+
+/** Thrown when the Python script crashes or produces invalid JSON. */
+export class PythonPluginError extends Error {
+	readonly toolName: string;
+	readonly exitCode: number | null;
+	readonly stderr: string;
+	readonly stdout: string;
+	constructor(
+		toolName: string,
+		exitCode: number | null,
+		stderr: string,
+		stdout: string,
+		hint?: string,
+	) {
+		super(
+			`python plugin "${toolName}" failed${hint ? `: ${hint}` : ""}${
+				exitCode !== null ? ` (exit=${exitCode})` : ""
+			}`,
+		);
+		this.name = "PythonPluginError";
+		this.toolName = toolName;
+		this.exitCode = exitCode;
+		this.stderr = stderr;
+		this.stdout = stdout;
+	}
+}
+
+/** Thrown when the subprocess overruns `timeoutMs`. */
+export class PythonPluginTimeoutError extends Error {
+	readonly toolName: string;
+	readonly timeoutMs: number;
+	constructor(toolName: string, timeoutMs: number) {
+		super(`python plugin "${toolName}" timed out after ${timeoutMs}ms`);
+		this.name = "PythonPluginTimeoutError";
+		this.toolName = toolName;
+		this.timeoutMs = timeoutMs;
+	}
+}
+
+export interface PythonPluginExecResult {
+	readonly value: unknown;
+	readonly stderr: string;
+	readonly durationMs: number;
+}
+
+/**
+ * Build a `ToolHandler` that shells out to `scriptPath`. Exported so
+ * consumers can pre-register individual Python tools (e.g. a vendored
+ * utility) without running the discovery step.
+ */
+export function makePythonPluginHandler(
+	toolName: string,
+	scriptPath: string,
+	options: PythonPluginOptions = {},
+): ToolHandler {
+	const pythonBin = options.pythonBin ?? DEFAULT_PYTHON_BIN;
+	const timeoutMs = options.timeoutMs === undefined
+		? DEFAULT_TIMEOUT_MS
+		: options.timeoutMs;
+	const envOverride = options.env;
+
+	return async (args, ctx) => {
+		if (!existsSync(scriptPath)) {
+			throw new PythonPluginError(
+				toolName,
+				null,
+				"",
+				"",
+				`script missing at ${scriptPath}`,
+			);
+		}
+
+		const env: NodeJS.ProcessEnv =
+			envOverride === undefined
+				? { ...process.env }
+				: (envOverride as NodeJS.ProcessEnv);
+
+		const t0 = Date.now();
+		let child: ChildProcessWithoutNullStreams;
+		try {
+			child = spawn(pythonBin, [scriptPath], {
+				cwd: options.cwd,
+				env,
+				stdio: ["pipe", "pipe", "pipe"],
+			});
+		} catch (err) {
+			throw new PythonPluginError(
+				toolName,
+				null,
+				"",
+				"",
+				`spawn failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+
+		const stdoutChunks: Buffer[] = [];
+		const stderrChunks: Buffer[] = [];
+		child.stdout.on("data", (c: Buffer) => stdoutChunks.push(c));
+		child.stderr.on("data", (c: Buffer) => stderrChunks.push(c));
+
+		// Feed args JSON to stdin + close.
+		try {
+			child.stdin.write(JSON.stringify(args ?? null));
+			child.stdin.end();
+		} catch {
+			// ignore — stdin closure errors surface via child exit code.
+		}
+
+		// Wire timeout + abort.
+		let timedOut = false;
+		let timer: NodeJS.Timeout | undefined;
+		if (typeof timeoutMs === "number" && timeoutMs > 0) {
+			timer = setTimeout(() => {
+				timedOut = true;
+				child.kill("SIGKILL");
+			}, timeoutMs);
+		}
+		const onAbort = () => child.kill("SIGKILL");
+		ctx.signal.addEventListener("abort", onAbort, { once: true });
+
+		const exit = await new Promise<{
+			code: number | null;
+			signal: NodeJS.Signals | null;
+			error?: Error;
+		}>((resolve) => {
+			// Spawn-time errors (e.g. ENOENT when the interpreter path is
+			// bogus) arrive via the 'error' event. Capture instead of
+			// rejecting so we can wrap consistently as PythonPluginError.
+			child.once("error", (error: Error) =>
+				resolve({ code: null, signal: null, error }),
+			);
+			child.once("close", (code, signal) => resolve({ code, signal }));
+		});
+
+		if (timer) clearTimeout(timer);
+		ctx.signal.removeEventListener("abort", onAbort);
+
+		const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+		const stderr = Buffer.concat(stderrChunks).toString("utf8");
+		const durationMs = Date.now() - t0;
+
+		if (exit.error) {
+			throw new PythonPluginError(
+				toolName,
+				null,
+				stderr,
+				stdout,
+				`spawn failed: ${exit.error.message}`,
+			);
+		}
+		if (timedOut) {
+			throw new PythonPluginTimeoutError(toolName, timeoutMs ?? 0);
+		}
+		if (ctx.signal.aborted) {
+			throw new PythonPluginError(
+				toolName,
+				exit.code,
+				stderr,
+				stdout,
+				"aborted by caller",
+			);
+		}
+		if (exit.code !== 0) {
+			throw new PythonPluginError(
+				toolName,
+				exit.code,
+				stderr,
+				stdout,
+				exit.signal ? `killed by ${exit.signal}` : "non-zero exit",
+			);
+		}
+
+		let value: unknown;
+		try {
+			value = stdout.length === 0 ? null : JSON.parse(stdout);
+		} catch {
+			throw new PythonPluginError(
+				toolName,
+				0,
+				stderr,
+				stdout,
+				"stdout was not valid JSON",
+			);
+		}
+
+		const result: PythonPluginExecResult = { value, stderr, durationMs };
+		// Plugin authors typically want just the value — expose full
+		// result shape via a wrapper if they need diagnostics. The
+		// common case returns `value`; the runAgent ToolCallAfter
+		// surfaces stderr via logs already.
+		return result.value;
+	};
+}
+
+// ─── Loader (extension priority + discovery) ────────────────────────
+
+async function fileExists(path: string): Promise<boolean> {
+	try {
+		const s = await stat(path);
+		return s.isFile();
+	} catch {
+		return false;
+	}
+}
+
+async function resolvePythonScript(
+	agentDir: string,
+	name: string,
+): Promise<string | null> {
+	const candidate = join(agentDir, "tools", `${name}.py`);
+	if (await fileExists(candidate)) return candidate;
+	return null;
+}
+
+export interface PythonLoadResult {
+	readonly loaded: readonly string[];
+	readonly skipped: readonly string[];
+	readonly missing: readonly string[];
+}
+
+/**
+ * For each tool in `spec.tools` that isn't already in `registry`,
+ * attempt to resolve a `.py` plugin and register a subprocess-backed
+ * handler. Returns the same loaded/skipped/missing breakdown the G3a
+ * loader uses so callers can compose them.
+ *
+ * Usage pattern — run the G3a loader first (prefers .mjs/.js), then
+ * this one for any remaining tool names:
+ *
+ *   const mj = await loadPluginTools(spec, registry);
+ *   const py = await loadPythonPlugins(spec, registry);
+ *   // mj.missing ∩ py.loaded  → resolved by Python
+ *   // mj.missing \ py.loaded  → genuinely unresolved
+ */
+export async function loadPythonPlugins(
+	spec: AgentSpec,
+	registry: ToolRegistry,
+	options: PythonPluginOptions = {},
+): Promise<PythonLoadResult> {
+	const loaded: string[] = [];
+	const skipped: string[] = [];
+	const missing: string[] = [];
+
+	for (const name of spec.tools) {
+		if (registry.has(name)) {
+			skipped.push(name);
+			continue;
+		}
+		const scriptPath = await resolvePythonScript(spec.dir, name);
+		if (!scriptPath) {
+			missing.push(name);
+			continue;
+		}
+		registry.register(
+			name,
+			makePythonPluginHandler(name, scriptPath, {
+				...options,
+				// Default cwd to the agent directory so plugins can use
+				// relative paths (e.g. to sibling SYSTEM.md / scope fixtures).
+				cwd: options.cwd ?? spec.dir,
+			}),
+		);
+		loaded.push(name);
+	}
+
+	return { loaded, skipped, missing };
+}

--- a/tests/sdk-python-plugin.test.ts
+++ b/tests/sdk-python-plugin.test.ts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import {
+	type AgentSpec,
+	createToolRegistry,
+	loadPythonPlugins,
+	makePythonPluginHandler,
+	PythonPluginError,
+	PythonPluginTimeoutError,
+} from "../src/sdk/index.js";
+
+function pythonAvailable(): boolean {
+	try {
+		execFileSync("python3", ["--version"], { stdio: "ignore" });
+		return true;
+	} catch {
+		try {
+			execFileSync("python", ["--version"], { stdio: "ignore" });
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}
+
+const HAVE_PYTHON = pythonAvailable();
+
+async function writePyPlugin(
+	dir: string,
+	name: string,
+	body: string,
+): Promise<string> {
+	const toolsDir = join(dir, "tools");
+	await mkdir(toolsDir, { recursive: true });
+	const path = join(toolsDir, `${name}.py`);
+	await writeFile(path, body, "utf8");
+	await chmod(path, 0o755);
+	return path;
+}
+
+function specFor(dir: string, tools: string[]): AgentSpec {
+	return {
+		dir,
+		schemaVersion: 1,
+		toolsApi: 1,
+		shape: "single-step",
+		tools,
+		extras: {},
+	} as AgentSpec;
+}
+
+const ctx = {
+	tool: "t",
+	sessionId: "s",
+	iteration: 1,
+	signal: new AbortController().signal,
+};
+
+describe("python plugin loader — discovery (G3b)", () => {
+	let root = "";
+	before(async () => {
+		root = await mkdtemp(join(tmpdir(), "py-loader-"));
+	});
+	after(async () => {
+		if (root) await rm(root, { recursive: true, force: true });
+	});
+
+	it("loads a .py plugin into the registry", async () => {
+		const agentDir = join(root, "load");
+		await writePyPlugin(
+			agentDir,
+			"echo",
+			'import json, sys\nargs = json.load(sys.stdin)\njson.dump({"echoed": args}, sys.stdout)\n',
+		);
+		const registry = createToolRegistry();
+		const result = await loadPythonPlugins(
+			specFor(agentDir, ["echo"]),
+			registry,
+		);
+		assert.deepEqual([...result.loaded], ["echo"]);
+		assert.equal(result.missing.length, 0);
+		assert.equal(registry.has("echo"), true);
+	});
+
+	it("skips names already present in the registry (pre-registered wins)", async () => {
+		const agentDir = join(root, "skip");
+		await writePyPlugin(
+			agentDir,
+			"pre",
+			'import json, sys\njson.dump({"from_py": True}, sys.stdout)\n',
+		);
+		const registry = createToolRegistry();
+		registry.register("pre", async () => ({ from_pre: true }));
+		const result = await loadPythonPlugins(
+			specFor(agentDir, ["pre"]),
+			registry,
+		);
+		assert.deepEqual([...result.skipped], ["pre"]);
+		assert.equal(result.loaded.length, 0);
+	});
+
+	it("records missing tools in result.missing", async () => {
+		const agentDir = join(root, "missing");
+		await mkdir(join(agentDir, "tools"), { recursive: true });
+		const registry = createToolRegistry();
+		const result = await loadPythonPlugins(
+			specFor(agentDir, ["nope"]),
+			registry,
+		);
+		assert.deepEqual([...result.missing], ["nope"]);
+	});
+
+	it("reports loaded/skipped/missing breakdown across a mixed spec", async () => {
+		const agentDir = join(root, "mixed");
+		await writePyPlugin(agentDir, "a", "import sys; sys.stdout.write('null')\n");
+		await writePyPlugin(agentDir, "c", "import sys; sys.stdout.write('null')\n");
+		const registry = createToolRegistry();
+		registry.register("b", async () => null);
+		const result = await loadPythonPlugins(
+			specFor(agentDir, ["a", "b", "c", "d"]),
+			registry,
+		);
+		assert.deepEqual([...result.loaded], ["a", "c"]);
+		assert.deepEqual([...result.skipped], ["b"]);
+		assert.deepEqual([...result.missing], ["d"]);
+	});
+});
+
+describe(
+	"python plugin handler — subprocess protocol (G3b)",
+	{ skip: !HAVE_PYTHON },
+	() => {
+		let root = "";
+		before(async () => {
+			root = await mkdtemp(join(tmpdir(), "py-handler-"));
+		});
+		after(async () => {
+			if (root) await rm(root, { recursive: true, force: true });
+		});
+
+		it("passes JSON args through stdin + returns parsed stdout JSON", async () => {
+			const script = await writePyPlugin(
+				root,
+				"double",
+				'import json, sys\nargs = json.load(sys.stdin)\njson.dump({"result": args["x"] * 2}, sys.stdout)\n',
+			);
+			const handler = makePythonPluginHandler("double", script);
+			const result = await handler({ x: 21 }, ctx);
+			assert.deepEqual(result, { result: 42 });
+		});
+
+		it("surfaces non-zero exit as PythonPluginError with stderr", async () => {
+			const script = await writePyPlugin(
+				root,
+				"crash",
+				'import sys\nsys.stderr.write("boom")\nraise SystemExit(3)\n',
+			);
+			const handler = makePythonPluginHandler("crash", script);
+			await assert.rejects(handler(null, ctx), (err: unknown) => {
+				assert.ok(err instanceof PythonPluginError);
+				const pe = err as PythonPluginError;
+				assert.equal(pe.toolName, "crash");
+				assert.equal(pe.exitCode, 3);
+				assert.match(pe.stderr, /boom/);
+				return true;
+			});
+		});
+
+		it("wraps non-JSON stdout as PythonPluginError with full capture", async () => {
+			const script = await writePyPlugin(
+				root,
+				"malformed",
+				'import sys\nsys.stdout.write("not json")\n',
+			);
+			const handler = makePythonPluginHandler("malformed", script);
+			await assert.rejects(handler({}, ctx), (err: unknown) => {
+				assert.ok(err instanceof PythonPluginError);
+				const pe = err as PythonPluginError;
+				assert.equal(pe.exitCode, 0);
+				assert.match(pe.stdout, /not json/);
+				assert.match(pe.message, /not valid JSON/);
+				return true;
+			});
+		});
+
+		it("returns null for an empty stdout (plugin explicitly returns nothing)", async () => {
+			const script = await writePyPlugin(root, "silent", "pass\n");
+			const handler = makePythonPluginHandler("silent", script);
+			const result = await handler({}, ctx);
+			assert.equal(result, null);
+		});
+
+		it("respects timeoutMs + throws PythonPluginTimeoutError", async () => {
+			const script = await writePyPlugin(
+				root,
+				"slow",
+				"import time\ntime.sleep(5)\n",
+			);
+			const handler = makePythonPluginHandler("slow", script, {
+				timeoutMs: 100,
+			});
+			await assert.rejects(handler({}, ctx), (err: unknown) => {
+				assert.ok(err instanceof PythonPluginTimeoutError);
+				assert.equal((err as PythonPluginTimeoutError).toolName, "slow");
+				assert.equal((err as PythonPluginTimeoutError).timeoutMs, 100);
+				return true;
+			});
+		});
+
+		it("honours AbortController — aborts kill the subprocess", async () => {
+			const script = await writePyPlugin(
+				root,
+				"wait",
+				"import time\ntime.sleep(10)\n",
+			);
+			const ac = new AbortController();
+			const handler = makePythonPluginHandler("wait", script);
+			setTimeout(() => ac.abort(), 50);
+			await assert.rejects(
+				handler({}, { ...ctx, signal: ac.signal }),
+				/aborted|killed/,
+			);
+		});
+
+		it("forwards env when passed + isolates when env={}", async () => {
+			const script = await writePyPlugin(
+				root,
+				"envread",
+				'import json, os, sys\njson.dump({"v": os.environ.get("RLMX_TEST_VAR", "<unset>")}, sys.stdout)\n',
+			);
+			const seen = await makePythonPluginHandler("envread", script, {
+				env: { RLMX_TEST_VAR: "hello", PATH: process.env.PATH ?? "" },
+			})({}, ctx);
+			assert.deepEqual(seen, { v: "hello" });
+			const isolated = await makePythonPluginHandler("envread", script, {
+				env: { PATH: process.env.PATH ?? "" },
+			})({}, ctx);
+			assert.deepEqual(isolated, { v: "<unset>" });
+		});
+
+		it("missing interpreter surfaces as PythonPluginError at call time", async () => {
+			const script = await writePyPlugin(root, "any", "pass\n");
+			const handler = makePythonPluginHandler("any", script, {
+				pythonBin: "/path/to/definitely/not/a/real/python",
+			});
+			await assert.rejects(handler({}, ctx), (err: unknown) => {
+				assert.ok(err instanceof PythonPluginError);
+				return true;
+			});
+		});
+
+		it("missing script file short-circuits with a clear error", async () => {
+			const handler = makePythonPluginHandler(
+				"ghost",
+				join(root, "tools", "nope.py"),
+			);
+			await assert.rejects(handler({}, ctx), (err: unknown) => {
+				assert.ok(err instanceof PythonPluginError);
+				assert.match(
+					(err as PythonPluginError).message,
+					/script missing/,
+				);
+				return true;
+			});
+		});
+	},
+);


### PR DESCRIPTION
## Summary

Closes the Python branch of the tool plugin loader. `.py` scripts under `<agent-dir>/tools/<name>.py` now register as SDK tools via a fresh-subprocess exec with a minimal JSON stdin/stdout protocol. No framework lock-in on the plugin side; no invasive change to `rlm.ts`, `cli.ts`, or any existing module. Additive only.

Depends on: #64, #65, #66, #67, #68 (all merged).

## Protocol

```python
#!/usr/bin/env python3
import json, sys
args = json.load(sys.stdin)
# ... tool logic ...
json.dump({"ok": True, "value": args["x"] * 2}, sys.stdout)
```

SDK side:

```ts
// Compose with the G3a loader — JS/MJS first, Python for the rest.
const js = await sdk.loadPluginTools(spec, registry);
const py = await sdk.loadPythonPlugins(spec, registry, {
	timeoutMs: 30_000,
	env: { PATH: process.env.PATH!, BRAIN_HOME: agentHome },
});
```

Every call spawns a fresh interpreter (no pooling), so state leakage between calls is structurally impossible. stderr is captured as diagnostic, never parsed.

## Change shape (4 files, +654/-4)

| file | purpose |
|---|---|
| `src/sdk/python-plugin.ts` (new) | `makePythonPluginHandler` + `loadPythonPlugins` + typed errors. |
| `src/sdk/index.ts` | Re-export the G3b surface. |
| `tests/sdk-python-plugin.test.ts` (new) | 13 tests — 4 hermetic discovery + 9 protocol (Python-gated). |
| `docs/events.md` | Python plugin section + updated scope boundary. |

## Error semantics

| condition | typed error |
|---|---|
| wall-clock overrun | `PythonPluginTimeoutError` (exposes `timeoutMs`) |
| non-zero exit | `PythonPluginError` (exposes `exitCode`, `stderr`, `stdout`) |
| malformed stdout JSON | `PythonPluginError` message: "stdout was not valid JSON" |
| interpreter not found | `PythonPluginError` message: "spawn failed: ENOENT..." |
| script file missing | `PythonPluginError` message: "script missing at ..." |
| abort mid-run | `PythonPluginError` message: "aborted by caller" |

Every error preserves full `stderr` + `stdout` so runAgent consumers can log them without re-running the tool.

## Verification

- `npm run check` → clean
- `npm run build` → ok
- `sdk-python-plugin.test.js` isolated (with `python3` installed) → **13 / 13 pass**
- Without `python3` → **4 / 4 discovery tests** pass; 9 protocol tests auto-skip
- SDK all isolated → **129 / 129 pass** across 22 suites
- `npm test` (full) → **334 / 334 pass** (was 321 post-G3a; +13 new, zero regression)

## Wish B G3 completion checkpoint

| criterion | status |
|---|---|
| `agent.yaml` with `tools: [...]` auto-loads TS/MJS | ✅ #68 |
| `agent.yaml` with `tools: [...]` auto-loads Python | ✅ this PR |
| RTK auto-detected + used | ✅ #68 |
| Per-depth metrics JSON emitted | ✅ #68 |
| RTK `run_cli` auto-prefix inside `rlm.ts` | unrelated CLI path — existing wiring |

## Scope boundary (out of this PR)

- `.ts` source plugins — still deferred (needs tsx / node TS loader).
- Heavy sandboxing (seccomp, namespaces, resource limits).
- Virtualenv / dependency management.
- Streaming partial results.
- Cross-language tool composition.
- CLI cutover — `rlmx "query"` still uses `rlmLoop`.

## Design decisions worth the review time

1. **Fresh subprocess per call, no pooling.** State leakage between calls is structurally impossible. The cost is ~50-100 ms interpreter startup per tool — acceptable for agent tool-call cadence (which is already sub-second LLM-bound).

2. **env passthrough by default.** Plugins typically need `PATH`, creds, and rlmx-style `BRAIN_HOME` / `BRAIN_AGENT_NAME` env. Passing `process.env` avoids surprises. Consumers can isolate with `env: {}`. (Documented inline.)

3. **cwd defaults to agent dir.** Matches the wish-A `BRAIN_HOME`-style path convention; lets plugins reference sibling files via relative paths without the SDK injecting another env var.

4. **Empty stdout → `null`.** Plugin explicitly choosing silence is a legitimate pattern (fire-and-forget tools). Throwing on empty stdout would force boilerplate `print("null")` everywhere.

5. **Spawn errors wrapped.** ENOENT from a bogus interpreter path emits the `'error'` event before `'close'` — I capture instead of rejecting, so the public error shape stays uniformly `PythonPluginError` regardless of whether the failure was spawn-time or runtime.

## Base + head

- Base: `dev` @ `edef7c0`
- Head: `bef95b7`
- Branch: `feat/python-tool-loader`

## Next after merge

Per WISH.md the remaining groups are:
- **G4**: documentation + 3 example agents
- **G5**: genie `RlmxExecutor` (consumer side, touches the genie repo)
- **G6-9**: schedule wiring, smoke, brain integration, backcompat, cascade

Your call on priority.