### PR TITLE
docs(sdk): overview + tool-authoring + agent schema + 3 example agents — Wish B G4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,44 @@ rlmx "Summarize this paper" --context paper.md --output json
 cat data.csv | rlmx "Analyze this dataset"
 ```
 
+## SDK (`rlmx.sdk.*`)
+
+rlmx also ships a programmatic SDK for consumers that need to drive
+agents from code — with per-iteration observability, permission
+hooks, validate-with-retry, session checkpointing, and a pluggable
+tool registry. The CLI path above is untouched; the SDK is purely
+additive.
+
+```ts
+import { sdk } from "@automagik/rlmx";
+
+const spec = await sdk.loadAgentSpec("./my-agent");
+const registry = sdk.createToolRegistry();
+await sdk.registerRtkTool(registry);
+await sdk.loadPluginTools(spec, registry);
+
+for await (const ev of sdk.runAgent({
+	agentId: "my-agent",
+	sessionId: "s-1",
+	input: "what's new?",
+	driver: sdk.rlmDriver({
+		model: { provider: "google", model: "gemini-2.5-flash" },
+		system: await Bun.file("./my-agent/SYSTEM.md").text(),
+	}),
+	toolRegistry: registry,
+})) {
+	console.log(ev.type, ev.timestamp);
+}
+```
+
+Deeper dives:
+
+- [`docs/sdk-overview.md`](docs/sdk-overview.md) — layered architecture + design principles.
+- [`docs/events.md`](docs/events.md) — the 12-event catalogue + emitter contract.
+- [`docs/tool-authoring.md`](docs/tool-authoring.md) — TS/MJS + Python plugin recipes, RTK integration.
+- [`docs/agent-yaml-schema.md`](docs/agent-yaml-schema.md) — `agent.yaml` field reference.
+- [`examples/`](examples/) — three runnable example agents (hello-world / research-agent / brain-triage) with smoke tests.
+
 ## RTK Integration (token savings)
 
 rlmx auto-detects [RTK](https://github.com/rtk-ai/rtk) and routes CLI subprocess calls through it when available, for 60-90% token savings on tool outputs.

--- a/docs/agent-yaml-schema.md
+++ b/docs/agent-yaml-schema.md
@@ -1,0 +1,144 @@
+# `agent.yaml` schema
+
+The agent folder's `agent.yaml` file is a small YAML mapping that the
+SDK's `parseAgentSpec` / `loadAgentSpec` turn into an `AgentSpec`.
+The schema is **deliberately minimal** — only the fields the SDK
+consumes are validated. Unknown keys are preserved on `AgentSpec.extras`
+so consumers (brain, genie, your project) can layer their own schema
+without forking the parser.
+
+## Minimal example
+
+```yaml
+schema_version: 1
+tools_api: 1
+
+shape: single-step
+model: gemini-2.5-flash
+
+tools:
+  - greet
+```
+
+Loaded:
+
+```ts
+const spec = await sdk.loadAgentSpec("/path/to/agent-dir");
+// spec = {
+//   dir: "/path/to/agent-dir",
+//   schemaVersion: 1,
+//   toolsApi: 1,
+//   shape: "single-step",
+//   model: "gemini-2.5-flash",
+//   tools: ["greet"],
+//   extras: {},
+// }
+```
+
+## Full reference
+
+```yaml
+# ─── Schema versioning ────────────────────────────────────────
+schema_version: 1            # or schemaVersion: 1   (both accepted)
+tools_api: 1                 # or toolsApi: 1
+
+# ─── Iteration shape (how the loop behaves) ──────────────────
+shape: single-step           # "single-step" | "loop" | "recurse"
+                             # Default: single-step
+
+# ─── Model selection (consumer-interpreted) ──────────────────
+model: gemini-2.5-flash      # free-form string; the SDK does not
+                             # validate — it's surfaced on AgentSpec
+                             # for the consumer's driver / rlmDriver.
+
+# ─── Tools ───────────────────────────────────────────────────
+tools:
+  - greet                    # Each name must resolve via the plugin
+  - search_corpus            # loader. Missing tools land on
+  - rtk                      # result.missing (or throw in strict mode).
+
+# ─── Scope hints (advisory, SDK does NOT enforce) ────────────
+scope:
+  reads:
+    - Conversas/*            # Glob patterns; consumers (brain's
+    - docs/**/*.md           # read() tool) enforce the policy.
+  writes:
+    - _pending/*
+
+# ─── Budget hints (advisory in the SDK today) ────────────────
+budget:
+  max_cost: 0.01             # USD per run (consumer-enforced)
+  max_iterations: 5          # Ceiling — consumer can pass to
+                             # runAgent({ maxIterations }).
+  max_depth: 3               # For recursive shapes.
+
+# ─── System prompt pointer ───────────────────────────────────
+system: SYSTEM.md            # Relative to agent dir. Consumer loads
+                             # the content and passes it to the
+                             # driver (e.g. rlmDriver({ system })).
+```
+
+## Field reference
+
+| field | type | default | status | notes |
+|---|---|---|---|---|
+| `schema_version` / `schemaVersion` | number | `1` | SDK reads | Bumped when the schema itself changes. |
+| `tools_api` / `toolsApi` | number | `1` | SDK reads | Bumped when the tool contract changes. |
+| `shape` | `"single-step" \| "loop" \| "recurse"` | `"single-step"` | SDK reads, enforces allowed values | Rejects unknown shapes with a named error. |
+| `model` | string | — | passthrough | Not validated. Consumers wire it into their driver. |
+| `tools` | string[] | `[]` | SDK reads | Empty strings are filtered. Duplicate names collapse (last wins at load). |
+| `system` | string | — | passthrough | Consumer is responsible for reading the file + handing its contents to the driver. |
+| `scope.reads` | string[] | — | passthrough | Advisory. Enforced by individual tool handlers (e.g. brain's `read`). |
+| `scope.writes` | string[] | — | passthrough | Advisory, same as above. |
+| `budget.max_cost` / `maxCost` | number | — | passthrough | Consumer threads it into their budget tracker. |
+| `budget.max_iterations` / `maxIterations` | number | — | SDK/consumer | Can be passed to `runAgent({ maxIterations })`. |
+| `budget.max_depth` / `maxDepth` | number | — | passthrough | For recursive shapes. |
+
+## Extras
+
+Any key not listed above is preserved on `AgentSpec.extras` so
+domain-specific schemas can layer without a parser fork:
+
+```yaml
+# agent.yaml
+schema_version: 1
+tools: [search_corpus]
+
+brain:
+  reader_inline_media: true
+  pending_writes_whitelist:
+    - _pending/**/*.yaml
+```
+
+```ts
+const spec = await sdk.loadAgentSpec("/path/to/agent");
+// spec.extras.brain === { reader_inline_media: true, pending_writes_whitelist: [...] }
+```
+
+## Errors the parser raises
+
+| condition | error |
+|---|---|
+| YAML syntax error | `Error: agent.yaml: parse error: ...` |
+| Top-level is not a mapping (e.g. a list or scalar) | `Error: agent.yaml: expected a YAML mapping at the top level` |
+| `shape` is set to an unsupported value | `Error: agent.yaml: shape must be one of single-step \| loop \| recurse, got "..."` |
+| `agent.yaml` file is missing (via `loadAgentSpec`) | `ENOENT` from `node:fs` |
+
+Non-strings, non-finite numbers, and other type drift default
+silently — the parser aims to be forgiving where there's no risk of
+surprise.
+
+## Consumer schema evolution
+
+When you need to validate additional fields — e.g. brain's
+`scope.reads` enforcement — layer your own validator on top of
+`AgentSpec.extras`. The SDK's parser is a floor, not a ceiling:
+
+```ts
+import { sdk } from "@automagik/rlmx";
+
+const spec = await sdk.loadAgentSpec(path);
+validateBrainExtras(spec.extras); // your layer; throws if non-compliant.
+const registry = sdk.createToolRegistry();
+// ... proceed ...
+```

--- a/docs/sdk-overview.md
+++ b/docs/sdk-overview.md
@@ -1,0 +1,113 @@
+# rlmx SDK — Overview
+
+The rlmx SDK lets you build **declarative, observable, resumable AI
+agents** from a folder of markdown + tool plugins. It sits alongside the
+existing rlmx CLI (`rlmx "query"`) — the CLI path keeps running the
+recursion engine in `src/rlm.ts` unchanged, while the SDK exposes a
+finer-grained, programmatic surface for consumers who want to drive the
+loop from their own code.
+
+## Layer diagram
+
+```
+┌────────────────────────────────────────────────────────┐
+│ Consumer code  (genie, brain, your app)                │
+└─────────────────────────▲──────────────────────────────┘
+                          │   runAgent(config) → EventStream
+                          │
+┌─────────────────────────┴──────────────────────────────┐
+│ Driver seam (IterationDriver)                          │
+│  • rlmDriver()       — live LLM via llmCompleteSimple  │
+│  • your own async*   — canned / tests / custom         │
+└─────────────────────────▲──────────────────────────────┘
+                          │
+┌─────────────────────────┴──────────────────────────────┐
+│ runAgent wire (src/sdk/agent.ts)                       │
+│  emits AgentStart → IterationStart → (Message |        │
+│        ToolCallBefore → ToolCallAfter)* → EmitDone |   │
+│        Error → IterationOutput → SessionClose          │
+│  runs: permission chain, validate retry, session ckpt │
+└─┬─────────▲─────────▲─────────▲──────────▲─────────────┘
+  │         │         │         │          │
+  ▼         │         │         │          │
+┌────┐  ┌───┴──┐  ┌───┴────┐ ┌──┴─────┐ ┌──┴──────┐
+│Ev. │  │Sess. │  │Permis- │ │Validate│ │Metrics  │
+│SDK │  │API   │  │sion    │ │prim.   │ │recorder │
+│(12 │  │+File │  │hooks   │ │+retry  │ │(depth-  │
+│type│  │Store │  │chain   │ │once    │ │aware)   │
+└────┘  └──────┘  └────────┘ └────────┘ └─────────┘
+```
+
+## Design principles
+
+**Additive only.** Every SDK slice is a new namespace under `rlmx.sdk.*`
+— no existing export shape changed, no CLI behaviour modified.
+Consumers on the SDK path opt in; everything else keeps working.
+
+**Pluggable seams, not invasive patches.** When the SDK needs to
+cooperate with existing rlmx pieces (LLM transport, RTK detection), it
+imports them and wraps them. It does not re-plumb `src/rlm.ts`
+internals. This trades some duplication for zero regression risk.
+
+**Events as the observability contract.** The 10 wish-spec event types
+(plus session lifecycle) are the sole surface consumers subscribe to.
+Anything else — metrics, per-depth accounting, retry hints — rides on
+existing event payloads as optional fields. `ALL_AGENT_EVENT_TYPES`
+stays small.
+
+**Env-gated live tests.** CI runs deterministic hermetic tests only.
+Live LLM smokes + Python protocol tests gate on env vars
+(`GEMINI_API_KEY`, `python3 --version`) so they degrade to SKIP rather
+than FAIL when the environment isn't there.
+
+**Backcompat is policy, not aspiration.** The existing `rlmx "query"`
+CLI is byte-for-byte identical to pre-SDK behaviour. The CLI cutover to
+use `runAgent()` is a deliberately separate slice.
+
+## Module map
+
+| path | role |
+|---|---|
+| `src/sdk/events.ts` | Event type union + `makeEvent`, `iso`, `isAgentEvent`, `ALL_AGENT_EVENT_TYPES`, `WISH_SPEC_EVENT_TYPES`. |
+| `src/sdk/emitter.ts` | Async-iterator `EventStream` + `createEmitter()`. |
+| `src/sdk/session.ts` | `SessionState`, `SessionStore`, `createFileSessionStore`, `resumeAgent`, `pauseAgent`. |
+| `src/sdk/permissions.ts` | `PermissionHook`, `runPermissionChain`, `composeHooks`, `ALLOW`. |
+| `src/sdk/validate.ts` | `parseValidateMd`, `validateAgainstSchema`, `shouldRetry`, `buildRetryHint`. |
+| `src/sdk/agent.ts` | `runAgent`, `AgentConfig`, `IterationDriver`, `IterationStep`, `ToolResolver`. |
+| `src/sdk/rlm-driver.ts` | `rlmDriver` + `formatRlmPrompt` + `RlmDriverConfig` — bridges `llmCompleteSimple` into `IterationDriver`. |
+| `src/sdk/agent-spec.ts` | `AgentSpec`, `parseAgentSpec`, `loadAgentSpec`, `resolveAgentPath`. |
+| `src/sdk/tool-registry.ts` | `ToolRegistry`, `createToolRegistry`, `toolRegistryAsResolver`, `UnknownToolError`, `ToolHandler`. |
+| `src/sdk/tool-loader.ts` | `loadPluginTools` (`.mjs` / `.js`) + `MissingPluginError` + `InvalidPluginError`. |
+| `src/sdk/python-plugin.ts` | `loadPythonPlugins`, `makePythonPluginHandler`, `PythonPluginError`, `PythonPluginTimeoutError`. |
+| `src/sdk/rtk-plugin.ts` | `registerRtkTool`. |
+| `src/sdk/metrics.ts` | `IterationMetrics`, `createMetricsRecorder`. |
+
+Public entry: `import { sdk } from "@automagik/rlmx"`.
+
+## When to use the SDK vs the CLI
+
+**Use the CLI (`rlmx "query"`)** when:
+- You're running an ad-hoc query against a markdown-configured agent
+  directory and you want the canonical rlmx iteration loop.
+- You need tight compatibility with the existing `rlmx.yaml`
+  configuration surface.
+- You don't need per-iteration observability or programmatic control.
+
+**Use the SDK (`sdk.runAgent(...)`)** when:
+- You're embedding agent execution in another program (genie, brain,
+  a service) and need to iterate events directly.
+- You want to checkpoint + resume sessions across process restarts.
+- You need permission hooks, per-depth metrics, or validate with
+  retry-hint feedback.
+- You're authoring tests that exercise agent behaviour without a live
+  LLM (canned `IterationDriver`).
+
+## Further reading
+
+- [`docs/events.md`](./events.md) — the 12-event catalogue + usage.
+- [`docs/tool-authoring.md`](./tool-authoring.md) — writing `.mjs`,
+  `.js`, and `.py` tool plugins.
+- [`docs/agent-yaml-schema.md`](./agent-yaml-schema.md) — the
+  `agent.yaml` reference.
+- [`examples/`](../examples/) — three runnable example agents with
+  smoke tests.

--- a/docs/tool-authoring.md
+++ b/docs/tool-authoring.md
@@ -1,0 +1,175 @@
+# Authoring tool plugins
+
+An rlmx agent is a folder with `agent.yaml`, optional `SYSTEM.md` /
+`VALIDATE.md`, and a `tools/` subdirectory of per-tool plugin files.
+The SDK loads those files at runtime and exposes each as a named
+handler `runAgent()` can dispatch. Three flavours are supported.
+
+## TS/MJS tool plugin
+
+File: `<agent-dir>/tools/<name>.mjs` (preferred) or `<name>.js`.
+
+```js
+// tools/greet.mjs
+export default async function greet(args, ctx) {
+	// args  — the payload from the IterationStep `tool_call`
+	// ctx   — { tool, sessionId, iteration, signal }
+	if (ctx.signal.aborted) throw new Error("aborted");
+	return { hello: args.name };
+}
+```
+
+Rules:
+
+- **Default export only.** The loader imports the module dynamically
+  and reads `module.default`. Named exports are ignored.
+- **Must be a function.** The default export must satisfy
+  `(args: unknown, ctx: ToolContext) => unknown | Promise<unknown>`.
+  Anything else throws `InvalidPluginError` at load time.
+- **Extension priority.** `.mjs` beats `.js` — pick one per name.
+- **TypeScript source (`.ts`) is not loaded in this revision.**
+  Compile to `.mjs` or `.js` first, or use `tsx`/`ts-node` in your
+  runtime. A future slice will add native TS loading.
+
+Loading:
+
+```ts
+import { sdk } from "@automagik/rlmx";
+
+const spec = await sdk.loadAgentSpec("/path/to/my-agent");
+const registry = sdk.createToolRegistry();
+const result = await sdk.loadPluginTools(spec, registry);
+// result: { loaded: ["greet"], skipped: [], missing: [] }
+```
+
+## Python tool plugin
+
+File: `<agent-dir>/tools/<name>.py`.
+
+```python
+#!/usr/bin/env python3
+"""tools/search_corpus.py — stdio-JSON tool."""
+import json, sys
+
+args = json.load(sys.stdin)
+# ... your logic ...
+result = {"hits": [{"id": i, "text": f"doc {i}"} for i in range(args["limit"])]}
+json.dump(result, sys.stdout)
+```
+
+Protocol:
+
+| direction | format | notes |
+|---|---|---|
+| stdin | JSON | Single value — what the agent sent as `tool_call.args`. |
+| stdout | JSON | Parsed by the SDK; malformed → `PythonPluginError`. |
+| stderr | free-form text | Captured but **not** interpreted. Surfaces via error payloads. |
+| exit 0 | success | stdout must be valid JSON (empty stdout → `null`). |
+| exit ≠ 0 | failure | `PythonPluginError` with `{exitCode, stderr, stdout}`. |
+
+Loading (compose with the TS/MJS loader):
+
+```ts
+const js = await sdk.loadPluginTools(spec, registry);       // .mjs / .js first
+const py = await sdk.loadPythonPlugins(spec, registry, {    // then .py for the rest
+	timeoutMs: 30_000,
+	// env is PROCESS.ENV by default — pass `{}` to isolate.
+	env: { PATH: process.env.PATH, BRAIN_HOME: agentHome },
+});
+```
+
+Options:
+
+| option | default | purpose |
+|---|---|---|
+| `pythonBin` | `"python3"` | Override for venv paths or vendored interpreters. |
+| `timeoutMs` | `30000` | Wall-clock budget. `null` disables. On overrun → `PythonPluginTimeoutError`. |
+| `env` | `process.env` | Subprocess env. `{}` for isolation. |
+| `cwd` | agent dir | `Path.cwd()` inside the plugin. |
+
+Error taxonomy:
+
+- `PythonPluginError` — non-zero exit, malformed stdout JSON, spawn
+  failure (`ENOENT` on missing interpreter), missing script file.
+  Always carries `exitCode`, `stderr`, `stdout`.
+- `PythonPluginTimeoutError` — wall-clock overrun (SIGKILL). Carries
+  `toolName`, `timeoutMs`.
+
+Every call spawns a fresh subprocess — no pooling, no state leakage.
+The ~50–100 ms interpreter startup is acceptable for sub-second
+LLM-bound tool cadence.
+
+## RTK as a first-class tool
+
+[RTK](https://crates.io/crates/rtk) ("rust token killer") is a CLI
+token-optimised subprocess runner. The SDK can register it as a
+drop-in tool named `"rtk"`.
+
+```ts
+const registered = await sdk.registerRtkTool(registry);
+// returns true when rtk is on PATH + the registry gained the tool,
+// false when rtk is absent (no-op — agents can still declare `rtk`
+// in agent.yaml and it will simply land on result.missing).
+```
+
+Handler signature:
+
+```ts
+const result = await registry.get("rtk")!(
+	{ cmd: ["cargo", "test", "--quiet"] },
+	ctx,
+);
+// result: { stdout, stderr, exitCode, durationMs }
+```
+
+Options:
+
+| option | default | purpose |
+|---|---|---|
+| `name` | `"rtk"` | Override — useful for "sandboxed vs raw" splits. |
+| `forceRegister` | `false` | Register the tool even when `rtk` is absent. Handler then fails at call time. |
+
+Pre-registered RTK takes precedence over any `tools/rtk.{mjs,js,py}`
+file on disk — the plugin loader reports such files on
+`result.skipped`. This mirrors the general **pre-registered handlers
+always win** invariant.
+
+## Handler context
+
+Every handler (TS / Python / RTK) receives a `ToolContext`:
+
+```ts
+interface ToolContext {
+	readonly tool: string;            // the agent-declared name
+	readonly sessionId: string;
+	readonly iteration: number;
+	readonly signal: AbortSignal;     // abort-at-boundaries
+}
+```
+
+Honour `ctx.signal.aborted` in long-running handlers. The Python
+loader already wires `signal.addEventListener("abort", ...)` to
+`SIGKILL` the subprocess; TS/MJS handlers should check at cooperative
+boundaries.
+
+## Testing a plugin hermetically
+
+```ts
+import { sdk } from "@automagik/rlmx";
+
+const registry = sdk.createToolRegistry();
+await sdk.loadPluginTools(spec, registry);
+const greet = registry.get("greet")!;
+const out = await greet({ name: "Stéfani" }, {
+	tool: "greet",
+	sessionId: "t",
+	iteration: 1,
+	signal: new AbortController().signal,
+});
+// assert on `out`
+```
+
+For full end-to-end coverage with the event stream + permission chain
++ session checkpoint, pass the registry to `runAgent({ toolRegistry })`
+and drive with a canned `IterationDriver`. See
+[`examples/`](../examples/) for runnable walk-throughs.

--- a/examples/brain-triage/README.md
+++ b/examples/brain-triage/README.md
@@ -1,0 +1,98 @@
+# Example — brain-triage
+
+Mirrors the `brain-triage` agent from the khal-os/brain repo (wish A
+foundation) in miniature. Demonstrates a Python-plugin tool wired
+into the SDK's tool registry, with the same folder shape brain's
+real agents use.
+
+```
+examples/brain-triage/
+├── agent.yaml           # tools: [search_corpus], shape: single-step
+├── SYSTEM.md            # role + output schema hint
+├── tools/
+│   └── search_corpus.py # stdin→JSON, stdout→JSON Python plugin
+└── README.md            # you are here
+```
+
+## What's inside the plugin
+
+A self-contained Python script with a 3-document fake corpus and a
+naive token-overlap scorer — no external dependencies, no vault to
+mount. Follow the SDK stdio-JSON protocol:
+
+```python
+args = json.load(sys.stdin)     # { query: "...", limit?: int }
+# ...
+json.dump(result, sys.stdout)   # { query, hits: [...] }
+```
+
+Run it standalone to verify (requires `python3`):
+
+```bash
+echo '{"query":"carol divorcio", "limit":2}' | python3 examples/brain-triage/tools/search_corpus.py
+```
+
+## Wiring — hermetic
+
+```ts
+import { join } from "node:path";
+import { sdk } from "@automagik/rlmx";
+
+const dir = join(import.meta.dir, "..", "examples", "brain-triage");
+const spec = await sdk.loadAgentSpec(dir);
+
+const registry = sdk.createToolRegistry();
+const py = await sdk.loadPythonPlugins(spec, registry, {
+	timeoutMs: 15_000,
+});
+// py.loaded === ["search_corpus"]
+
+const driver = async function* (req) {
+	yield {
+		kind: "tool_call",
+		tool: "search_corpus",
+		args: { query: req.history[0].content, limit: 1 },
+	};
+	yield {
+		kind: "emit_done",
+		payload: {
+			query: req.history[0].content,
+			best_match_id: "case-001",
+			confidence: 0.82,
+			reason: "top hit with highest token overlap",
+		},
+	};
+};
+
+for await (const ev of sdk.runAgent({
+	agentId: "brain-triage",
+	sessionId: `triage-${Date.now()}`,
+	input: "carol divorcio",
+	driver,
+	toolRegistry: registry,
+})) {
+	console.log(ev.type);
+}
+```
+
+## Cross-repo story
+
+In the real brain repo (`khal-os/brain`), an equivalent agent lives at
+`.agents/triage/` with `brain/python/brain_tools.py` providing the
+real `search_corpus`, `read`, and `propose_yaml` tools. That runner
+currently wraps the Python tools via its own CLI path; once brain
+adopts the SDK directly, the agent folder can load through
+`loadPythonPlugins` with zero change to the Python side. This example
+proves the SDK's side of that contract in isolation.
+
+## Smoke test
+
+`tests/example-brain-triage.test.ts` runs the full loop with the real
+Python subprocess + asserts:
+- `search_corpus` resolves from `.py` (not shadowed by a TS/MJS miss).
+- The tool call executes and returns a result shape matching
+  `{ query, hits: Array<{ id, title, score, snippet }> }`.
+- `SessionClose{reason:"complete"}` fires.
+
+Test auto-skips when `python3` is unavailable, matching the broader
+G3b behaviour.

--- a/examples/brain-triage/SYSTEM.md
+++ b/examples/brain-triage/SYSTEM.md
@@ -1,0 +1,16 @@
+# Triage agent (example)
+
+Mirror of the `brain-triage` agent wired in the khal-os/brain repo
+(wish A foundation). Given a short query, call `search_corpus` once,
+pick the single best hit, and emit a structured decision:
+
+```json
+{
+	"query": "<the input>",
+	"best_match_id": "<result id>",
+	"confidence": 0.0 - 1.0,
+	"reason": "<one-line justification>"
+}
+```
+
+Single iteration. No follow-up questions.

--- a/examples/brain-triage/agent.yaml
+++ b/examples/brain-triage/agent.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+tools_api: 1
+
+shape: single-step
+model: gemini-2.5-flash-lite
+
+tools:
+  - search_corpus
+
+system: SYSTEM.md
+
+scope:
+  reads:
+    - corpus/*
+
+budget:
+  max_cost: 0.01
+  max_iterations: 2

--- a/examples/brain-triage/tools/search_corpus.py
+++ b/examples/brain-triage/tools/search_corpus.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+tools/search_corpus.py — example Python tool plugin.
+
+Demonstrates the SDK's stdio-JSON protocol:
+
+    stdin:  args JSON
+    stdout: result JSON
+    stderr: diagnostic (captured, never parsed)
+
+The fake corpus is embedded below so this example is completely
+self-contained — no external downloads, no vault to mount. Replace
+CORPUS with a real BM25 / pg_search hit list when you adapt this
+pattern for a real agent.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from typing import Any
+
+
+CORPUS: list[dict[str, Any]] = [
+    {
+        "id": "case-001",
+        "title": "Divórcio Carol",
+        "text": "audiência 14h Carol divórcio consensual 2026",
+    },
+    {
+        "id": "case-002",
+        "title": "ITCMD Reginaldo",
+        "text": "ITCMD valor mínimo doação Reginaldo inventário",
+    },
+    {
+        "id": "client-042",
+        "title": "Jhenifer — contrato",
+        "text": "contrato de prestação Jhenifer 2026-04 assinatura",
+    },
+]
+
+
+def _score(query: str, doc: dict[str, Any]) -> int:
+    """Naive token-overlap score — one point per query token that
+    appears in the title or text. Deterministic, no dependencies."""
+    q_tokens = {t for t in re.split(r"\W+", query.lower()) if t}
+    doc_tokens = set(
+        re.split(r"\W+", (doc.get("title", "") + " " + doc.get("text", "")).lower())
+    )
+    return len(q_tokens & doc_tokens)
+
+
+def search(query: str, limit: int = 3) -> list[dict[str, Any]]:
+    scored = sorted(
+        ((doc, _score(query, doc)) for doc in CORPUS),
+        key=lambda pair: pair[1],
+        reverse=True,
+    )
+    return [
+        {
+            "id": doc["id"],
+            "title": doc["title"],
+            "score": score,
+            "snippet": doc["text"][:160],
+        }
+        for doc, score in scored
+        if score > 0
+    ][:limit]
+
+
+def main() -> None:
+    args = json.load(sys.stdin)
+    query = args.get("query", "")
+    limit = args.get("limit", 3)
+
+    if not isinstance(query, str) or not query.strip():
+        # Surface a diagnostic to stderr — the SDK captures it for
+        # the ToolCallAfter event, so the agent sees the reason
+        # without the run aborting.
+        sys.stderr.write("search_corpus: empty query\n")
+        json.dump({"hits": [], "reason": "empty query"}, sys.stdout)
+        return
+
+    hits = search(query.strip(), int(limit))
+    json.dump({"query": query, "hits": hits}, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,63 @@
+# Example — hello-world
+
+The absolute minimum rlmx agent: one TS tool, one iteration, one
+greeting. Proof-of-life for the SDK plumbing.
+
+```
+examples/hello-world/
+├── agent.yaml           # declares the `greet` tool
+├── SYSTEM.md            # system prompt pointer
+├── tools/
+│   └── greet.mjs        # the tool plugin (default export = async fn)
+└── README.md            # you are here
+```
+
+## Running with a canned driver (hermetic)
+
+```ts
+import { join } from "node:path";
+import { sdk } from "@automagik/rlmx";
+
+const here = join(import.meta.dir, "..", "examples", "hello-world");
+
+const spec = await sdk.loadAgentSpec(here);
+const registry = sdk.createToolRegistry();
+await sdk.loadPluginTools(spec, registry);
+
+const driver = async function* (req) {
+	yield {
+		kind: "tool_call",
+		tool: "greet",
+		args: { name: req.history[0].content },
+	};
+	yield { kind: "emit_done", payload: { ok: true } };
+};
+
+for await (const ev of sdk.runAgent({
+	agentId: "hello-world",
+	sessionId: `hello-${Date.now()}`,
+	input: "Stéfani",
+	driver,
+	toolRegistry: registry,
+})) {
+	console.log(ev.type, ev.timestamp);
+}
+```
+
+The smoke test at `tests/example-hello-world.test.ts` exercises this
+flow against the real plugin loader and asserts the tool fires with
+the expected name.
+
+## Running with a live LLM (opt-in)
+
+Wrap `rlmDriver` instead of the canned async generator:
+
+```ts
+const driver = sdk.rlmDriver({
+	model: { provider: "google", model: "gemini-2.5-flash" },
+	system: await readFile(join(here, "SYSTEM.md"), "utf8"),
+});
+```
+
+Needs a `GEMINI_API_KEY` or `GOOGLE_API_KEY` in env. Cost per run: a
+fraction of a cent for a single-shot model turn.

--- a/examples/hello-world/SYSTEM.md
+++ b/examples/hello-world/SYSTEM.md
@@ -1,0 +1,7 @@
+# Hello, world
+
+You are a friendly greeting agent. When asked to greet someone, call
+the `greet` tool with their name as the argument and emit the result.
+
+Respond in ONE iteration. No follow-up questions; if you don't have a
+name, greet "stranger".

--- a/examples/hello-world/agent.yaml
+++ b/examples/hello-world/agent.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+tools_api: 1
+
+shape: single-step
+model: gemini-2.5-flash
+
+tools:
+  - greet
+
+system: SYSTEM.md

--- a/examples/hello-world/tools/greet.mjs
+++ b/examples/hello-world/tools/greet.mjs
@@ -1,0 +1,18 @@
+/**
+ * tools/greet.mjs — the minimum-viable rlmx tool.
+ *
+ * Demonstrates the default-export-is-an-async-function contract the
+ * SDK's plugin loader resolves. Runs in-process (no subprocess), so
+ * the only dependency is the function signature.
+ */
+
+export default async function greet(args, ctx) {
+	if (ctx.signal.aborted) {
+		throw new Error("greet: aborted");
+	}
+	const name =
+		typeof args === "object" && args !== null && typeof args.name === "string"
+			? args.name.trim() || "stranger"
+			: "stranger";
+	return { greeting: `Hello, ${name}!` };
+}

--- a/examples/research-agent/README.md
+++ b/examples/research-agent/README.md
@@ -1,0 +1,119 @@
+# Example — research-agent
+
+Multi-tool agent that demonstrates the full Wish B feature set:
+- **Tool plugin loader** resolves `fetch-url` from `tools/`.
+- **RTK native** auto-registers when `rtk` is on PATH (no config needed).
+- **Permission hooks** block internal hosts before the fetch fires.
+- **Validate primitive** enforces a structured output schema via
+  `VALIDATE.md` with retry-once on malformed payloads.
+- **Session checkpointing** persists history across iterations.
+
+```
+examples/research-agent/
+├── agent.yaml           # tools: [fetch-url, rtk]
+├── SYSTEM.md            # agent role + instructions
+├── VALIDATE.md          # JSON schema fence the validator enforces
+├── tools/
+│   └── fetch-url.mjs    # HTTP GET with strip-HTML pass
+└── README.md            # you are here
+```
+
+## Wiring — hermetic
+
+```ts
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { sdk } from "@automagik/rlmx";
+
+const dir = join(import.meta.dir, "..", "examples", "research-agent");
+const spec = await sdk.loadAgentSpec(dir);
+
+const registry = sdk.createToolRegistry();
+await sdk.registerRtkTool(registry); // auto — no-op if rtk absent
+await sdk.loadPluginTools(spec, registry);
+
+const validateMd = await readFile(join(dir, "VALIDATE.md"), "utf8");
+const { schema, rawBlock } = sdk.parseValidateMd(validateMd);
+
+// Canned driver for the smoke test (full flow, no LLM):
+const driver = async function* (req) {
+	if (req.iteration === 1) {
+		yield {
+			kind: "tool_call",
+			tool: "fetch-url",
+			args: { url: "https://example.com" },
+		};
+		yield {
+			kind: "emit_done",
+			payload: {
+				summary: "Example.com is an IANA reserved domain.",
+				citations: [
+					{ url: "https://example.com", note: "Primary source" },
+				],
+			},
+		};
+	} else {
+		yield {
+			kind: "emit_done",
+			payload: {
+				summary: "insufficient evidence",
+				citations: [],
+			},
+		};
+	}
+};
+
+for await (const ev of sdk.runAgent({
+	agentId: "research",
+	sessionId: `research-${Date.now()}`,
+	input: "What is example.com?",
+	driver,
+	toolRegistry: registry,
+	validateSchema: schema ?? undefined,
+	validateSchemaSource: rawBlock ?? undefined,
+	permissionHooks: [
+		// Block internal hosts — pair with fetch-url to demonstrate
+		// permission-hook composition.
+		(ctx) => {
+			if (ctx.tool !== "fetch-url") return { decision: "allow" };
+			const args = ctx.args as { url?: string } | null;
+			const url = args?.url ?? "";
+			if (
+				/^https?:\/\/(localhost|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/.test(
+					url,
+				)
+			) {
+				return { decision: "deny", reason: "internal host blocked" };
+			}
+			return { decision: "allow" };
+		},
+	],
+})) {
+	console.log(ev.type);
+}
+```
+
+## Wiring — live LLM
+
+Swap the canned driver for `sdk.rlmDriver`:
+
+```ts
+const driver = sdk.rlmDriver({
+	model: { provider: "google", model: "gemini-2.5-flash" },
+	system: await readFile(join(dir, "SYSTEM.md"), "utf8"),
+});
+```
+
+Needs `GEMINI_API_KEY` in env.
+
+## What the smoke test proves
+
+See `tests/example-research-agent.test.ts`:
+
+- `fetch-url` loads from `tools/` and returns a structured result.
+- Validate accepts the good payload on iteration 1 → `EmitDone` fires
+  + `SessionClose{reason:"complete"}`.
+- The permission hook rejects a `localhost` fetch with the expected
+  `Error{phase:"tool-denied"}` event.
+- Bad payload (missing `citations`) triggers retry with a hint — the
+  next iteration sees `req.retryHint`.

--- a/examples/research-agent/SYSTEM.md
+++ b/examples/research-agent/SYSTEM.md
@@ -1,0 +1,11 @@
+# Research agent
+
+Tools available:
+
+- `fetch-url`   — HTTP GET a public URL, return `{ text, status, url }`.
+- `rtk`         — run a CLI command via RTK; returns `{ stdout, stderr, exitCode, durationMs }`.
+
+Call these tools to gather evidence, then emit a structured final
+payload matching `VALIDATE.md`. Prefer primary sources. If no useful
+evidence surfaces in three iterations, emit a payload with
+`summary: "insufficient evidence"` and an empty `citations` array.

--- a/examples/research-agent/VALIDATE.md
+++ b/examples/research-agent/VALIDATE.md
@@ -1,0 +1,28 @@
+# Output schema
+
+The agent must emit a JSON payload shaped like:
+
+```json
+{
+	"type": "object",
+	"required": ["summary", "citations"],
+	"properties": {
+		"summary": { "type": "string" },
+		"citations": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"required": ["url", "note"],
+				"properties": {
+					"url": { "type": "string" },
+					"note": { "type": "string" }
+				}
+			}
+		}
+	}
+}
+```
+
+`summary` is a single paragraph (~3-5 sentences). `citations` lists the
+URLs consulted with a one-line note per citation. Emit an empty
+citations array only when `summary === "insufficient evidence"`.

--- a/examples/research-agent/agent.yaml
+++ b/examples/research-agent/agent.yaml
@@ -1,0 +1,15 @@
+schema_version: 1
+tools_api: 1
+
+shape: loop
+model: gemini-2.5-flash
+
+tools:
+  - fetch-url
+  - rtk
+
+system: SYSTEM.md
+
+budget:
+  max_cost: 0.05
+  max_iterations: 6

--- a/examples/research-agent/tools/fetch-url.mjs
+++ b/examples/research-agent/tools/fetch-url.mjs
@@ -1,0 +1,56 @@
+/**
+ * tools/fetch-url.mjs — HTTP GET + basic HTML→text extraction.
+ *
+ * Demonstrates:
+ *   - Tool that touches the outside world (network). The consumer
+ *     should pair this with a permission hook that blocks internal
+ *     hosts — see the example below + the smoke test.
+ *   - Abort-at-boundaries via ctx.signal.
+ *   - Structured return shape for downstream validate/citations.
+ */
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export default async function fetchUrl(args, ctx) {
+	if (!args || typeof args !== "object") {
+		throw new TypeError("fetch-url: args must be an object");
+	}
+	const url = typeof args.url === "string" ? args.url : null;
+	if (!url) {
+		throw new TypeError("fetch-url: args.url must be a string");
+	}
+
+	const timeoutMs = Number.isFinite(args.timeoutMs) ? args.timeoutMs : DEFAULT_TIMEOUT_MS;
+	const timer = AbortSignal.timeout(timeoutMs);
+	// Compose caller's abort with the tool-level timeout so whichever
+	// fires first cancels the fetch.
+	const signal = AbortSignal.any([ctx.signal, timer]);
+
+	let res;
+	try {
+		res = await fetch(url, { signal });
+	} catch (err) {
+		throw new Error(`fetch-url: request failed — ${err.message}`);
+	}
+
+	const contentType = res.headers.get("content-type") ?? "";
+	const body = await res.text();
+	const text = contentType.includes("text/html")
+		? stripHtml(body)
+		: body;
+
+	return {
+		url: res.url,
+		status: res.status,
+		text: text.slice(0, 8_000), // keep payloads bounded
+	};
+}
+
+function stripHtml(html) {
+	return html
+		.replace(/<script[\s\S]*?<\/script>/gi, " ")
+		.replace(/<style[\s\S]*?<\/style>/gi, " ")
+		.replace(/<[^>]+>/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}

--- a/tests/example-brain-triage.test.ts
+++ b/tests/example-brain-triage.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+	type AgentEvent,
+	createToolRegistry,
+	loadAgentSpec,
+	loadPythonPlugins,
+	runAgent,
+} from "../src/sdk/index.js";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const EXAMPLE_DIR = join(testDir, "..", "..", "examples", "brain-triage");
+
+function pythonAvailable(): boolean {
+	try {
+		execFileSync("python3", ["--version"], { stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function drain(
+	stream: AsyncIterable<AgentEvent>,
+): Promise<AgentEvent[]> {
+	const out: AgentEvent[] = [];
+	for await (const ev of stream) out.push(ev);
+	return out;
+}
+
+describe(
+	"example: brain-triage (G4, skip when no python3)",
+	{ skip: !pythonAvailable() },
+	() => {
+		it("loads agent.yaml + tools/search_corpus.py via Python subprocess", async () => {
+			const spec = await loadAgentSpec(EXAMPLE_DIR);
+			assert.deepEqual([...spec.tools], ["search_corpus"]);
+
+			const registry = createToolRegistry();
+			const py = await loadPythonPlugins(spec, registry, {
+				timeoutMs: 10_000,
+			});
+			assert.deepEqual([...py.loaded], ["search_corpus"]);
+
+			const driver = async function* (req: {
+				history: ReadonlyArray<{ content: string }>;
+			}) {
+				yield {
+					kind: "tool_call" as const,
+					tool: "search_corpus",
+					args: { query: req.history[0]?.content ?? "", limit: 2 },
+				};
+				yield {
+					kind: "emit_done" as const,
+					payload: {
+						query: req.history[0]?.content ?? "",
+						best_match_id: "case-001",
+						confidence: 0.82,
+						reason: "top hit from token overlap",
+					},
+				};
+			};
+
+			const events = await drain(
+				runAgent({
+					agentId: "brain-triage",
+					sessionId: `triage-${Date.now()}`,
+					input: "carol divorcio",
+					driver,
+					toolRegistry: registry,
+					maxIterations: 2,
+				}),
+			);
+
+			const after = events.find((e) => e.type === "ToolCallAfter") as
+				| { tool: string; ok: boolean; result: unknown }
+				| undefined;
+			assert.ok(after);
+			assert.equal(after?.tool, "search_corpus");
+			assert.equal(after?.ok, true);
+			const result = after?.result as {
+				query: string;
+				hits: Array<{ id: string; title: string; score: number; snippet: string }>;
+			};
+			assert.equal(result.query, "carol divorcio");
+			assert.ok(Array.isArray(result.hits));
+			assert.ok(result.hits.length > 0, "expected at least one hit for 'carol divorcio'");
+			// The token-overlap scorer puts case-001 (Carol divórcio) at rank 1.
+			assert.equal(result.hits[0]?.id, "case-001");
+
+			const close = events.find((e) => e.type === "SessionClose") as
+				| { reason: string }
+				| undefined;
+			assert.equal(close?.reason, "complete");
+		});
+
+		it("python plugin handles an empty-query fall-through", async () => {
+			const spec = await loadAgentSpec(EXAMPLE_DIR);
+			const registry = createToolRegistry();
+			await loadPythonPlugins(spec, registry, { timeoutMs: 5_000 });
+			const handler = registry.get("search_corpus");
+			assert.ok(handler);
+			const result = (await handler!(
+				{ query: "   " },
+				{
+					tool: "search_corpus",
+					sessionId: "s",
+					iteration: 1,
+					signal: new AbortController().signal,
+				},
+			)) as { hits: unknown[]; reason?: string };
+			assert.equal(result.reason, "empty query");
+			assert.deepEqual(result.hits, []);
+		});
+	},
+);

--- a/tests/example-hello-world.test.ts
+++ b/tests/example-hello-world.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import {
+	type AgentEvent,
+	createToolRegistry,
+	loadAgentSpec,
+	loadPluginTools,
+	runAgent,
+} from "../src/sdk/index.js";
+
+// tests/ compiles to dist/tests/. From there the examples/ root sits
+// two levels up; resolve once here for every test in this file.
+const testDir = dirname(fileURLToPath(import.meta.url));
+const EXAMPLE_DIR = join(testDir, "..", "..", "examples", "hello-world");
+
+async function drain(
+	stream: AsyncIterable<AgentEvent>,
+): Promise<AgentEvent[]> {
+	const out: AgentEvent[] = [];
+	for await (const ev of stream) out.push(ev);
+	return out;
+}
+
+describe("example: hello-world (G4)", () => {
+	it("loads agent.yaml + tools/greet.mjs and dispatches a greeting", async () => {
+		const spec = await loadAgentSpec(EXAMPLE_DIR);
+		assert.deepEqual([...spec.tools], ["greet"]);
+		assert.equal(spec.shape, "single-step");
+
+		const registry = createToolRegistry();
+		const result = await loadPluginTools(spec, registry);
+		assert.deepEqual([...result.loaded], ["greet"]);
+		assert.equal(result.missing.length, 0);
+
+		const driver = async function* (req: {
+			history: ReadonlyArray<{ content: string }>;
+		}) {
+			yield {
+				kind: "tool_call" as const,
+				tool: "greet",
+				args: { name: req.history[0]?.content ?? "stranger" },
+			};
+			yield { kind: "emit_done" as const, payload: { ok: true } };
+		};
+
+		const events = await drain(
+			runAgent({
+				agentId: "hello-world",
+				sessionId: `hello-${Date.now()}`,
+				input: "Stéfani",
+				driver,
+				toolRegistry: registry,
+				maxIterations: 2,
+			}),
+		);
+
+		const after = events.find((e) => e.type === "ToolCallAfter") as
+			| { tool: string; result: unknown; ok: boolean }
+			| undefined;
+		assert.ok(after);
+		assert.equal(after?.tool, "greet");
+		assert.equal(after?.ok, true);
+		assert.deepEqual(after?.result, { greeting: "Hello, Stéfani!" });
+
+		const close = events.find((e) => e.type === "SessionClose") as
+			| { reason: string }
+			| undefined;
+		assert.equal(close?.reason, "complete");
+	});
+});

--- a/tests/example-research-agent.test.ts
+++ b/tests/example-research-agent.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+	type AgentEvent,
+	createToolRegistry,
+	loadAgentSpec,
+	loadPluginTools,
+	parseValidateMd,
+	type PermissionHook,
+	registerRtkTool,
+	runAgent,
+	type ToolHandler,
+} from "../src/sdk/index.js";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const EXAMPLE_DIR = join(testDir, "..", "..", "examples", "research-agent");
+
+async function drain(
+	stream: AsyncIterable<AgentEvent>,
+): Promise<AgentEvent[]> {
+	const out: AgentEvent[] = [];
+	for await (const ev of stream) out.push(ev);
+	return out;
+}
+
+// Hermetic fake fetch — swap in for `fetch-url` so the smoke test
+// doesn't hit the network. Uses registry.override so the plugin
+// file load happens (exercising the real .mjs discovery path) and
+// THEN we replace it.
+const fakeFetch: ToolHandler = async (args) => {
+	const { url } = args as { url: string };
+	return {
+		url,
+		status: 200,
+		text: "Example Domain — IANA reserved domain (RFC 6761 / RFC 2606).",
+	};
+};
+
+describe("example: research-agent (G4)", () => {
+	it("loads agent.yaml + tools + validates a good payload", async () => {
+		const spec = await loadAgentSpec(EXAMPLE_DIR);
+		assert.deepEqual(new Set(spec.tools), new Set(["fetch-url", "rtk"]));
+
+		const registry = createToolRegistry();
+		// Auto-register RTK when available — no-op otherwise, so the
+		// test is portable. The plugin loader will still see `rtk` in
+		// agent.yaml and either skip (pre-registered) or register the
+		// file (when present).
+		await registerRtkTool(registry);
+		const loadResult = await loadPluginTools(spec, registry);
+		assert.ok(loadResult.loaded.includes("fetch-url"));
+
+		// Swap the real fetch for the fake so the test stays hermetic.
+		registry.override("fetch-url", fakeFetch);
+
+		const validateMd = await readFile(join(EXAMPLE_DIR, "VALIDATE.md"), "utf8");
+		const { schema, rawBlock } = parseValidateMd(validateMd);
+		assert.ok(schema, "VALIDATE.md must parse to a schema");
+
+		const driver = async function* () {
+			yield {
+				kind: "tool_call" as const,
+				tool: "fetch-url",
+				args: { url: "https://example.com" },
+			};
+			yield {
+				kind: "emit_done" as const,
+				payload: {
+					summary: "Example.com is an IANA reserved domain.",
+					citations: [
+						{ url: "https://example.com", note: "Primary source" },
+					],
+				},
+			};
+		};
+
+		const events = await drain(
+			runAgent({
+				agentId: "research",
+				sessionId: `research-${Date.now()}`,
+				input: "What is example.com?",
+				driver,
+				toolRegistry: registry,
+				validateSchema: schema ?? undefined,
+				validateSchemaSource: rawBlock ?? undefined,
+				maxIterations: 3,
+			}),
+		);
+
+		const validation = events.find((e) => e.type === "Validation") as
+			| { status: string; attempt: number }
+			| undefined;
+		assert.equal(validation?.status, "pass");
+		const close = events.find((e) => e.type === "SessionClose") as
+			| { reason: string }
+			| undefined;
+		assert.equal(close?.reason, "complete");
+	});
+
+	it("permission hook blocks localhost fetches", async () => {
+		const spec = await loadAgentSpec(EXAMPLE_DIR);
+		const registry = createToolRegistry();
+		await loadPluginTools(spec, registry);
+		registry.override("fetch-url", fakeFetch);
+
+		const denyInternal: PermissionHook = (ctx) => {
+			if (ctx.tool !== "fetch-url") return { decision: "allow" };
+			const args = ctx.args as { url?: string } | null;
+			const url = args?.url ?? "";
+			if (/^https?:\/\/(localhost|127\.|10\.|192\.168\.)/.test(url)) {
+				return { decision: "deny", reason: "internal host blocked" };
+			}
+			return { decision: "allow" };
+		};
+
+		const driver = async function* () {
+			yield {
+				kind: "tool_call" as const,
+				tool: "fetch-url",
+				args: { url: "http://localhost:3000/admin" },
+			};
+			yield {
+				kind: "emit_done" as const,
+				payload: {
+					summary: "insufficient evidence",
+					citations: [],
+				},
+			};
+		};
+
+		const events = await drain(
+			runAgent({
+				agentId: "research-deny",
+				sessionId: `research-deny-${Date.now()}`,
+				input: "poke internal",
+				driver,
+				toolRegistry: registry,
+				permissionHooks: [denyInternal],
+				maxIterations: 2,
+			}),
+		);
+
+		const denial = events.find(
+			(e) =>
+				e.type === "Error" &&
+				(e as { phase: string }).phase === "tool-denied",
+		);
+		assert.ok(denial, "expected Error{phase:tool-denied}");
+		const after = events.find((e) => e.type === "ToolCallAfter") as
+			| { ok: boolean }
+			| undefined;
+		assert.equal(after?.ok, false);
+	});
+
+	it("validate retry-with-hint triggers when payload is malformed", async () => {
+		const spec = await loadAgentSpec(EXAMPLE_DIR);
+		const registry = createToolRegistry();
+		await loadPluginTools(spec, registry);
+		registry.override("fetch-url", fakeFetch);
+
+		const validateMd = await readFile(join(EXAMPLE_DIR, "VALIDATE.md"), "utf8");
+		const { schema, rawBlock } = parseValidateMd(validateMd);
+		assert.ok(schema);
+
+		let iterationSeen = 0;
+		let retryHintSeen = "";
+		const driver = async function* (req: { iteration: number; retryHint?: string }) {
+			iterationSeen = req.iteration;
+			if (req.retryHint) retryHintSeen = req.retryHint;
+			if (req.iteration === 1) {
+				// Missing `citations` — should fail validate.
+				yield {
+					kind: "emit_done" as const,
+					payload: { summary: "bare summary" },
+				};
+			} else {
+				yield {
+					kind: "emit_done" as const,
+					payload: {
+						summary: "corrected summary",
+						citations: [],
+					},
+				};
+			}
+		};
+
+		const events = await drain(
+			runAgent({
+				agentId: "research-retry",
+				sessionId: `research-retry-${Date.now()}`,
+				input: "prompt",
+				driver,
+				toolRegistry: registry,
+				validateSchema: schema ?? undefined,
+				validateSchemaSource: rawBlock ?? undefined,
+				maxIterations: 3,
+			}),
+		);
+
+		const validations = events.filter((e) => e.type === "Validation") as Array<{
+			status: string;
+		}>;
+		assert.equal(validations[0]?.status, "fail");
+		assert.equal(validations[1]?.status, "pass");
+		assert.equal(iterationSeen, 2);
+		assert.match(retryHintSeen, /VALIDATE\.md/);
+	});
+});


### PR DESCRIPTION
## Summary

Closes WISH.md G4: a documentation pass over the Wish B SDK surface plus three runnable example agents that each exercise a different slice of the primitives end-to-end. Additive; no existing modules touched beyond the README.

Depends on: #64, #65, #66, #67, #68, #69 (all merged).

## Change shape (20 files, +1420/-0)

### Docs
| file | role |
|---|---|
| `README.md` | New "SDK (rlmx.sdk.*)" section with quick-start + doc link tree. CLI content above unchanged. |
| `docs/sdk-overview.md` (new) | Layered architecture diagram, design principles, module map, SDK-vs-CLI guidance. |
| `docs/tool-authoring.md` (new) | Three recipes: TS/MJS plugin, Python plugin (stdio-JSON protocol + options + error taxonomy), RTK native. |
| `docs/agent-yaml-schema.md` (new) | Full `agent.yaml` field reference, consumer-extras pattern, parser error list. |

### Example agents
| path | demonstrates |
|---|---|
| `examples/hello-world/` | minimal TS tool plugin; 1 smoke test |
| `examples/research-agent/` | fetch-url TS plugin + RTK auto-register + `VALIDATE.md` schema + permission hook + retry-once; 3 smoke tests |
| `examples/brain-triage/` | Python plugin via stdio-JSON; mirrors khal-os/brain's `.agents/triage/` shape; 2 smoke tests (auto-skip without python3) |

### Smoke tests
| file | suites / tests |
|---|---|
| `tests/example-hello-world.test.ts` | 1 / 1 |
| `tests/example-research-agent.test.ts` | 1 / 3 (validate pass / permission deny / retry-with-hint) |
| `tests/example-brain-triage.test.ts` | 1 / 2 (full subprocess roundtrip / empty-query fallthrough) |

Each test uses canned `IterationDriver`s and the real plugin loader — hermetic by default, but every code path is traversed exactly as production would traverse it.

## Verification

- `npm run check` → clean
- `npm run build` → ok
- Example tests isolated → **6 / 6 pass** across 3 suites
- `npm test` (full) → **340 / 340 pass** (was 334 post-G3b; +6 new, zero regression)

## Design decisions worth flagging

1. **Examples live under `examples/` not in `src/**/*`.** tsconfig's `include` stays unchanged so the build output (`dist/src`, `dist/tests`) is not polluted with example fixtures. Tests resolve example paths via `fileURLToPath(import.meta.url)` + `"../../examples/..."` which works cleanly from `dist/tests/*.test.js`.

2. **`examples/research-agent` uses a fake `fetch-url` handler in the smoke test.** `registry.override("fetch-url", fakeFetch)` preserves the plugin-file-discovery exercise (real `.mjs` load) while keeping the test hermetic (no network). The example's docs still reference the real HTTP path for operators running it live.

3. **Python example tests auto-skip when `python3` is unavailable.** Matches the G3b convention — CI stays portable; local devs with Python get full coverage.

4. **Each example's `README.md` documents both hermetic and live-LLM paths.** Operators trying the examples can copy either snippet without the docs hedging.

## Wish B completion

With G4 landing, 7 PRs cover the entire WISH.md L110-212 foundation:

| group | PR | status |
|---|---|---|
| G1 events + emitter | #64 | ✅ merged |
| G2 session / perm / validate | #65 | ✅ merged |
| G2b runAgent + wire | #66 | ✅ merged |
| G2c rlmDriver + live smoke | #67 | ✅ merged |
| G3a TS loader + RTK + metrics | #68 | ✅ merged |
| G3b Python loader | #69 | ✅ merged |
| G4 docs + 3 examples | this PR | ← |

Remaining per WISH.md: G5 (genie RlmxExecutor, consumer side), G6-9 (schedule / smoke / brain integration / backcompat / cascade).

## Scope boundary (out of this PR)

- Video / screencast assets.
- Publishing examples as separate npm packages.
- Cross-repo sync to wire brain's `.agents/triage` through the SDK (separate cutover).
- G5+ groups.

## Base + head

- Base: `dev` @ `36b9d11`
- Head: `082a797`
- Branch: `feat/docs-examples`