### PR TITLE
chore(build): prepare hook self-builds dist/ for git-URL consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "node --test dist/tests/*.test.js",
-    "prepare": "husky",
+    "prepare": "node scripts/prepare.mjs",
     "bump-version": "node scripts/version.mjs",
     "check": "tsc --noEmit"
   },

--- a/scripts/prepare.mjs
+++ b/scripts/prepare.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Cross-context `prepare` hook.
+ *
+ * npm / bun run `prepare` in two very different situations:
+ *
+ *   1. **Local development checkout** — `npm install` inside rlmx's
+ *      own repo. husky is present as a devDependency; we want it to
+ *      set up git hooks. Downstream consumers haven't installed us
+ *      yet, so building `dist/` is nice-to-have (covered by `npm run
+ *      build` when the dev actually works).
+ *
+ *   2. **Git-URL install by a consumer** — e.g.
+ *      `npm install git+https://github.com/automagik-dev/rlmx#<sha>`.
+ *      Consumers only install our `dependencies`, so husky is NOT
+ *      present. But they rely on our `main` field
+ *      (`./dist/src/index.js`) which DOES NOT EXIST in git (we publish
+ *      it via the `files` field in the npm tarball, which git doesn't
+ *      mirror). So we must build `dist/` at install time.
+ *
+ * This script handles both: try to run husky (no-op in consumer
+ * context where it's missing), then run the build unconditionally.
+ * Any build failure is loud — a consumer with a broken install is a
+ * landmine; better to fail the install than to leave it silent.
+ *
+ * Spec: dogfood-fresh + simone feedback on brain PR #352's dist-copy
+ * caveat (2026-04-22).
+ */
+
+import { spawnSync } from "node:child_process";
+
+function run(cmd, args, opts = {}) {
+	const r = spawnSync(cmd, args, {
+		stdio: "inherit",
+		shell: process.platform === "win32",
+		...opts,
+	});
+	return r.status ?? 1;
+}
+
+function runOptional(cmd, args) {
+	const r = spawnSync(cmd, args, {
+		stdio: ["ignore", "ignore", "ignore"],
+		shell: process.platform === "win32",
+	});
+	// Silently ignore — husky absence isn't an error in a consumer
+	// install, only a dev-env miss.
+	return r.status === 0;
+}
+
+// 1. husky — dev git hooks. Silent fallthrough when missing.
+runOptional("husky", []);
+
+// 2. build — required in consumer contexts. Loud failure.
+const buildStatus = run("npm", ["run", "build"]);
+if (buildStatus !== 0) {
+	console.error(
+		`[rlmx prepare] build failed (exit ${buildStatus}). dist/ not produced — consumers will fail to import. See the build output above.`,
+	);
+	process.exit(buildStatus);
+}


### PR DESCRIPTION
## Summary

Closes the install landmine dogfood-fresh + simone surfaced during the brain rlmx-SDK bridge slice (khal-os/brain PR #352). Consumers installing rlmx via git URL now get a working `dist/` automatically at install time instead of needing a manual `cp -r /path/to/rlmx/dist .` workaround.

Depends on: #64, #65, #66, #67, #68, #69, #70 (all merged, Wish B foundation complete).

## The problem

The prior `prepare` script was `"prepare": "husky"`. That works for local development (husky devDep is present, sets up git hooks). But when a consumer runs `npm install git+https://github.com/automagik-dev/rlmx.git#<sha>`:

1. npm/bun fetches the repo.
2. The `files` field in `package.json` ships `dist/src` + `src/templates` + `python/*.py` + `examples` — but the **git repo never has a committed `dist/`**. `dist/` only exists in the npm tarball, which `npm publish` builds via the `prepare` script.
3. With the old `prepare: husky`, no build ran during consumer install → `dist/` didn't exist → `main: ./dist/src/index.js` pointed at a non-existent file → consumers hit `MODULE_NOT_FOUND` at import time.

Workaround consumers used until now:

```bash
bun install
cp -r /path/to/rlmx/dist node_modules/@automagik/rlmx/
```

Not acceptable as a long-term requirement.

## The fix

New `scripts/prepare.mjs` runs two steps unconditionally when `prepare` fires:

1. **husky** — silent fallthrough when absent. Only matters in dev context where hooks need setting up; a consumer install has no `.git` or husky devDep and would crash loudly. Silent ignore is the correct semantic here.
2. **npm run build** — required in consumer contexts. Runs `tsc && cp src/benchmark-data.json dist/src/ && cp -r src/templates dist/src/templates`. **Failure is LOUD** — an install that silently produces broken output is worse than an install that errors visibly.

Why it works in both contexts:

- **Dev** (`npm install` inside rlmx): husky + typescript + everything present. Both steps succeed.
- **Consumer git-URL install**: npm/bun installs ALL dependencies of the package-being-installed (including devDeps) in a temp staging dir, runs `prepare`, then packages up per the `files` field and drops it in the consumer's `node_modules/`. typescript IS available during `prepare`; husky ISN'T needed (and `runOptional()` swallows its absence).

## Verification

**Dev context:**
```bash
rm -rf dist
npm run prepare
# → husky runs
# → tsc + templates
# → dist/src/**/*.js appears
```

**Consumer simulation:**
```bash
mkdir /tmp/rlmx-install-test && cd /tmp/rlmx-install-test
npm init -y
npm install /home/genie/repos/rlmx
ls node_modules/@automagik/rlmx/dist/src/sdk/
# → agent-spec.js, agent.js, emitter.js, events.js, index.js, metrics.js, ...
```

Both passed.

**Regression check:**
- `npm run check` (`tsc --noEmit`) → clean
- `npm test` → **340 / 340 pass** (same as post-G4 baseline)
- No runtime code touched.

## Change shape (2 files, +62/-1)

| file | purpose |
|---|---|
| `scripts/prepare.mjs` (new) | Cross-context hook: husky (optional) + build (required). Loud on build failure. |
| `package.json` | `"prepare": "husky"` → `"prepare": "node scripts/prepare.mjs"`. |

## Scope boundary (out of this PR)

- No runtime code changed.
- No tests touched.
- No event/API surface changes.
- `typescript` + `husky` stay in devDependencies (correct — they ARE available during npm's install-of-this-package step even when the top-level consumer didn't include devDeps for their own project).

## Base + head

- Base: `dev` @ `93c7d22`
- Head: `c8b5f29`
- Branch: `feat/prepare-build-hook`

## After this merges

Downstream consumers (starting with brain's `feat/brain-rlmx-sdk-bridge` branch, already merged) can drop the `cp -r dist/` workaround from their setup docs. Future brain bumps of `@automagik/rlmx` in package.json will land a working dist automatically.