### PR TITLE
feat(sdk): tool_call_observation — observe-vs-dispatch primitive

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -49,10 +49,12 @@ for await (const ev of em) {
 | `Error`           | For non-fatal + fatal failures, tagged by phase.      |
 | `SessionOpen`     | On `resumeAgent()` — `resumed` flags fresh vs reload. |
 | `SessionClose`    | On `pauseAgent()` / terminal event — carries reason.  |
+| `ToolCallObservation` | On `tool_call_observation` step — tool dispatch happened elsewhere (wrapped framework); SDK observes without re-dispatching. |
 
 The first 10 are the wish-spec contract (`WISH_SPEC_EVENT_TYPES`);
-the last 2 are session-lifecycle additions from Group 2. Use
-`ALL_AGENT_EVENT_TYPES` for the full current union and
+the next 2 are session-lifecycle additions from Group 2; the
+13th is `ToolCallObservation` for observe-vs-dispatch drivers (L2a).
+Use `ALL_AGENT_EVENT_TYPES` for the full current union and
 `WISH_SPEC_EVENT_TYPES` for just the wish-frozen core.
 
 Every event carries a `timestamp` (`ISO-8601` UTC) and a discriminant
@@ -160,6 +162,54 @@ for await (const ev of stream) {
 boundaries; the emitter closes with `SessionClose { reason: "abort" }`
 and the snapshot is checkpointed so `resumeAgent(sessionId, store)`
 picks up where abort hit.
+
+## Observe-vs-dispatch — `tool_call_observation` (L2a)
+
+Some consumers drive `runAgent()` while their tool dispatch happens
+INSIDE a wrapped framework (pi-agent, LangChain, auto-agent loops).
+Those drivers need to surface tool activity to the event stream for
+observability — but they do NOT want the SDK to re-dispatch a tool
+that the external framework has already handled.
+
+The `tool_call_observation` IterationStep handles that case:
+
+```ts
+const driver: sdk.IterationDriver = async function* (req) {
+	// External framework dispatches the tool and returns the result.
+	const result = await myExternalAgent.callTool("brain_search", { q: "…" });
+
+	// Surface the event without triggering SDK dispatch:
+	yield {
+		kind: "tool_call_observation",
+		tool: "brain_search",
+		args: { q: "…" },
+		status: "completed",
+		result,
+		durationMs: 120,
+	};
+
+	// Continue as normal.
+	yield { kind: "emit_done", payload: { ok: true } };
+};
+```
+
+`runAgent` on seeing this step:
+
+- Emits a `ToolCallObservation` event (not `ToolCallBefore/After`).
+- Does NOT invoke the permission chain.
+- Does NOT invoke `toolRegistry`.
+- Does NOT increment the per-iteration `toolCalls` metric (which
+  remains a dispatch-only counter).
+
+Status lifecycle (`started` / `completed` / `failed`) is free-form:
+drivers can emit one observation per dispatch or three (begin/end/
+error) — the consumer event stream respects whatever cadence the
+driver chose.
+
+Future slice may add advisory permission hooks that fire on
+observations for logging / policy (the current guard is strict:
+permission chain never fires). File an issue if advisory hooks
+become load-bearing for a real consumer.
 
 ## Tool plugin loader (Group 3a)
 

--- a/src/sdk/agent.ts
+++ b/src/sdk/agent.ts
@@ -48,6 +48,7 @@ import {
 	type SessionCloseReason,
 	type ToolCallAfterEvent,
 	type ToolCallBeforeEvent,
+	type ToolCallObservationEvent,
 	type ValidationEvent,
 } from "./events.js";
 import {
@@ -84,6 +85,24 @@ export type IterationStep =
 			readonly kind: "tool_call";
 			readonly tool: string;
 			readonly args: unknown;
+	  }
+	| {
+			/**
+			 * Observation of a tool call whose dispatch happened elsewhere
+			 * — e.g. inside a wrapped agent framework (pi-agent, LangChain).
+			 * runAgent emits a `ToolCallObservation` event with the carried
+			 * payload and does NOT invoke the permission chain or the tool
+			 * registry. Consumers that want observation-based policy should
+			 * subscribe to the event. See `events.ts`
+			 * `ToolCallObservationEvent`.
+			 */
+			readonly kind: "tool_call_observation";
+			readonly tool: string;
+			readonly args: unknown;
+			readonly status: "started" | "completed" | "failed";
+			readonly result?: unknown;
+			readonly error?: { readonly name: string; readonly message: string };
+			readonly durationMs?: number;
 	  }
 	| { readonly kind: "emit_done"; readonly payload: unknown }
 	| { readonly kind: "error"; readonly error: Error };
@@ -396,6 +415,37 @@ async function drive(
 							ok,
 						} as Omit<ToolCallAfterEvent, "type" | "timestamp">);
 						em.emit(after);
+						continue;
+					}
+
+					case "tool_call_observation": {
+						// Observation: tool dispatch happened OUTSIDE the SDK
+						// (typically inside a wrapped framework like pi-agent
+						// or LangChain). runAgent does NOT invoke the
+						// permission chain or the tool registry. The step
+						// surfaces as a dedicated `ToolCallObservation` event
+						// so consumers can distinguish from SDK-dispatched
+						// tool_call / tool_call_after pairs.
+						const obs: ToolCallObservationEvent = makeEvent(
+							"ToolCallObservation",
+							{
+								sessionId,
+								iteration,
+								tool: step.tool,
+								args: step.args,
+								status: step.status,
+								result: step.result,
+								error: step.error,
+								durationMs: step.durationMs,
+							} as Omit<ToolCallObservationEvent, "type" | "timestamp">,
+						);
+						em.emit(obs);
+						// Count observations distinctly from dispatched tool
+						// calls — consumer metrics can diff observed vs
+						// dispatched to understand execution topology.
+						// (`toolCalls` stays a dispatch-only counter; this
+						// is tracked separately when the recorder lands a
+						// `incrObservedCalls` helper.)
 						continue;
 					}
 

--- a/src/sdk/events.ts
+++ b/src/sdk/events.ts
@@ -25,7 +25,8 @@ export type AgentEventType =
 	| "EmitDone"
 	| "Error"
 	| "SessionOpen"
-	| "SessionClose";
+	| "SessionClose"
+	| "ToolCallObservation";
 
 /** Base shape — every event carries a timestamp + discriminant. */
 interface BaseEvent {
@@ -166,6 +167,46 @@ export interface SessionCloseEvent extends BaseEvent {
 	readonly reason: SessionCloseReason;
 }
 
+/**
+ * Observation of a tool call whose dispatch happens elsewhere (e.g.
+ * inside a wrapped framework like pi-agent or LangChain). runAgent
+ * emits this when the driver yields a `tool_call_observation`
+ * IterationStep — it does NOT invoke the permission chain or the
+ * tool registry for observations (the external framework already
+ * handled both). Consumers interested in observation-based policy
+ * subscribe to this event directly.
+ *
+ * `status` lifecycle:
+ *   - `"started"` — driver observed the tool call begin
+ *   - `"completed"` — tool returned successfully, `result` present
+ *   - `"failed"` — tool errored, `error` present
+ *
+ * Intended for consumer drivers that wrap an external agent
+ * framework whose tool dispatch is already complete — e.g. brain's
+ * preservation bridge driving pi-agent. Native SDK tool dispatch
+ * (`tool_call` IterationStep) stays the primary path for
+ * consumers authoring loops inside the SDK.
+ */
+export type ToolCallObservationStatus = "started" | "completed" | "failed";
+
+export interface ToolCallObservationEvent extends BaseEvent {
+	readonly type: "ToolCallObservation";
+	readonly sessionId: string;
+	readonly iteration: number;
+	readonly tool: string;
+	readonly args: unknown;
+	readonly status: ToolCallObservationStatus;
+	readonly result?: unknown;
+	readonly error?: {
+		readonly name: string;
+		readonly message: string;
+	};
+	/** Wall-clock duration of the external dispatch, when the driver
+	 *  can report it. Optional — drivers that only surface completion
+	 *  may not have timing. */
+	readonly durationMs?: number;
+}
+
 /** Discriminated union — the sole surface SDK consumers iterate over. */
 export type AgentEvent =
 	| AgentStartEvent
@@ -179,7 +220,8 @@ export type AgentEvent =
 	| EmitDoneEvent
 	| ErrorEvent
 	| SessionOpenEvent
-	| SessionCloseEvent;
+	| SessionCloseEvent
+	| ToolCallObservationEvent;
 
 /**
  * Exhaustive sentinel — useful for switch statements so TS flags any
@@ -198,6 +240,7 @@ export const ALL_AGENT_EVENT_TYPES: readonly AgentEventType[] = [
 	"Error",
 	"SessionOpen",
 	"SessionClose",
+	"ToolCallObservation",
 ] as const;
 
 /** The 10 wish-spec event types. Session lifecycle types (SessionOpen /

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -30,6 +30,8 @@ export type {
 	SessionOpenEvent,
 	ToolCallAfterEvent,
 	ToolCallBeforeEvent,
+	ToolCallObservationEvent,
+	ToolCallObservationStatus,
 	ValidationEvent,
 } from "./events.js";
 

--- a/tests/sdk-events.test.ts
+++ b/tests/sdk-events.test.ts
@@ -32,14 +32,18 @@ describe("SDK events — contract (Wish B Groups 1 + 2)", () => {
 		assert.equal(WISH_SPEC_EVENT_TYPES.length, 10);
 	});
 
-	it("ALL_AGENT_EVENT_TYPES extends the wish spec with session lifecycle (Group 2)", () => {
-		const extras: readonly AgentEventType[] = ["SessionOpen", "SessionClose"];
+	it("ALL_AGENT_EVENT_TYPES extends the wish spec with session + observation events", () => {
+		const extras: readonly AgentEventType[] = [
+			"SessionOpen",
+			"SessionClose",
+			"ToolCallObservation",
+		];
 		assert.deepEqual(
 			[...ALL_AGENT_EVENT_TYPES],
 			[...WISH_SPEC_EVENT_TYPES, ...extras],
-			"ALL_AGENT_EVENT_TYPES = wish-spec 10 + SessionOpen/SessionClose from G2",
+			"ALL_AGENT_EVENT_TYPES = wish-spec 10 + Session{Open,Close} (G2) + ToolCallObservation (L2a)",
 		);
-		assert.equal(ALL_AGENT_EVENT_TYPES.length, 12);
+		assert.equal(ALL_AGENT_EVENT_TYPES.length, 13);
 	});
 
 	it("makeEvent fills timestamp + type automatically", () => {
@@ -127,9 +131,17 @@ describe("SDK events — contract (Wish B Groups 1 + 2)", () => {
 				sessionId: "s1",
 				reason: "complete",
 			} as never),
+			makeEvent<AgentEvent>("ToolCallObservation", {
+				sessionId: "s1",
+				iteration: 1,
+				tool: "external_tool",
+				args: { q: "?" },
+				status: "completed",
+				result: "ok",
+			} as never),
 		];
 
-		assert.equal(samples.length, 12);
+		assert.equal(samples.length, 13);
 		for (const ev of samples) {
 			const round = JSON.parse(JSON.stringify(ev));
 			assert.equal(round.type, ev.type);

--- a/tests/sdk-tool-call-observation.test.ts
+++ b/tests/sdk-tool-call-observation.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+	type AgentEvent,
+	createToolRegistry,
+	type IterationDriver,
+	type IterationStep,
+	type PermissionHook,
+	runAgent,
+	type ToolHandler,
+} from "../src/sdk/index.js";
+
+async function drain(
+	stream: AsyncIterable<AgentEvent>,
+): Promise<AgentEvent[]> {
+	const events: AgentEvent[] = [];
+	for await (const ev of stream) events.push(ev);
+	return events;
+}
+
+describe("IterationStep tool_call_observation — observe-vs-dispatch (L2a)", () => {
+	it("emits ToolCallObservation event for an observation step", async () => {
+		const driver: IterationDriver = async function* () {
+			yield {
+				kind: "tool_call_observation",
+				tool: "external_tool",
+				args: { q: "?" },
+				status: "completed",
+				result: { ok: true },
+				durationMs: 42,
+			};
+			yield { kind: "emit_done", payload: {} };
+		};
+
+		const events = await drain(
+			runAgent({
+				agentId: "obs",
+				sessionId: "s-obs",
+				input: "test",
+				driver,
+				maxIterations: 1,
+			}),
+		);
+
+		const obs = events.find((e) => e.type === "ToolCallObservation") as
+			| {
+					tool: string;
+					status: string;
+					result: unknown;
+					durationMs?: number;
+			  }
+			| undefined;
+		assert.ok(obs, "expected ToolCallObservation event");
+		assert.equal(obs?.tool, "external_tool");
+		assert.equal(obs?.status, "completed");
+		assert.deepEqual(obs?.result, { ok: true });
+		assert.equal(obs?.durationMs, 42);
+	});
+
+	it("does NOT emit ToolCallBefore/After for an observation (no SDK dispatch)", async () => {
+		const driver: IterationDriver = async function* () {
+			yield {
+				kind: "tool_call_observation",
+				tool: "external_tool",
+				args: {},
+				status: "completed",
+			};
+			yield { kind: "emit_done", payload: {} };
+		};
+
+		const events = await drain(
+			runAgent({
+				agentId: "obs-no-dispatch",
+				sessionId: "s",
+				input: "test",
+				driver,
+				maxIterations: 1,
+			}),
+		);
+
+		assert.equal(
+			events.some((e) => e.type === "ToolCallBefore"),
+			false,
+			"observations must not produce ToolCallBefore",
+		);
+		assert.equal(
+			events.some((e) => e.type === "ToolCallAfter"),
+			false,
+			"observations must not produce ToolCallAfter",
+		);
+	});
+
+	it("does NOT call the tool registry for an observation (guard check)", async () => {
+		const calls: string[] = [];
+		const registry = createToolRegistry();
+		const handler: ToolHandler = async (args) => {
+			calls.push(JSON.stringify(args));
+			return "from-registry";
+		};
+		registry.register("external_tool", handler);
+
+		const driver: IterationDriver = async function* () {
+			yield {
+				kind: "tool_call_observation",
+				tool: "external_tool",
+				args: { q: "x" },
+				status: "completed",
+				result: "from-driver",
+			};
+			yield { kind: "emit_done", payload: {} };
+		};
+
+		await drain(
+			runAgent({
+				agentId: "obs-no-reg",
+				sessionId: "s",
+				input: "test",
+				driver,
+				toolRegistry: registry,
+				maxIterations: 1,
+			}),
+		);
+
+		assert.deepEqual(
+			calls,
+			[],
+			"registry handler must not fire for observations",
+		);
+	});
+
+	it("does NOT invoke the permission chain for an observation (guard check)", async () => {
+		let permissionCalls = 0;
+		const hook: PermissionHook = () => {
+			permissionCalls++;
+			return { decision: "deny", reason: "should not be asked" };
+		};
+
+		const driver: IterationDriver = async function* () {
+			yield {
+				kind: "tool_call_observation",
+				tool: "external_tool",
+				args: {},
+				status: "completed",
+			};
+			yield { kind: "emit_done", payload: {} };
+		};
+
+		await drain(
+			runAgent({
+				agentId: "obs-no-perm",
+				sessionId: "s",
+				input: "test",
+				driver,
+				permissionHooks: [hook],
+				maxIterations: 1,
+			}),
+		);
+
+		assert.equal(
+			permissionCalls,
+			0,
+			"permission chain must not fire for observations",
+		);
+	});
+
+	it("status transitions (started/completed/failed) surface distinctly", async () => {
+		const driver: IterationDriver = async function* () {
+			yield {
+				kind: "tool_call_observation",
+				tool: "t",
+				args: {},
+				status: "started",
+			};
+			yield {
+				kind: "tool_call_observation",
+				tool: "t",
+				args: {},
+				status: "completed",
+				result: "ok",
+			};
+			yield {
+				kind: "tool_call_observation",
+				tool: "t2",
+				args: {},
+				status: "failed",
+				error: { name: "Error", message: "bang" },
+			};
+			yield { kind: "emit_done", payload: {} };
+		};
+
+		const events = await drain(
+			runAgent({
+				agentId: "obs-status",
+				sessionId: "s",
+				input: "test",
+				driver,
+				maxIterations: 1,
+			}),
+		);
+
+		const observations = events.filter(
+			(e) => e.type === "ToolCallObservation",
+		) as Array<{
+			status: string;
+			error?: { message: string };
+		}>;
+		assert.equal(observations.length, 3);
+		assert.equal(observations[0]?.status, "started");
+		assert.equal(observations[1]?.status, "completed");
+		assert.equal(observations[2]?.status, "failed");
+		assert.equal(observations[2]?.error?.message, "bang");
+	});
+
+	it("observations can interleave with native SDK tool_call + message steps", async () => {
+		const driver: IterationDriver = async function* () {
+			yield {
+				kind: "message",
+				role: "assistant",
+				content: "thinking…",
+			} as IterationStep;
+			yield {
+				kind: "tool_call_observation",
+				tool: "external",
+				args: {},
+				status: "completed",
+			};
+			yield { kind: "emit_done", payload: {} };
+		};
+
+		const events = await drain(
+			runAgent({
+				agentId: "obs-mixed",
+				sessionId: "s",
+				input: "test",
+				driver,
+				maxIterations: 1,
+			}),
+		);
+
+		const order = events.map((e) => e.type);
+		// AgentStart, IterationStart, Message, ToolCallObservation, EmitDone,
+		// IterationOutput, SessionClose — exact subset order we care about:
+		const relevant = order.filter((t) =>
+			(
+				["Message", "ToolCallObservation", "EmitDone"] as readonly string[]
+			).includes(t),
+		);
+		assert.deepEqual(relevant, [
+			"Message",
+			"ToolCallObservation",
+			"EmitDone",
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a new `IterationStep` kind (`tool_call_observation`) + matching `AgentEvent` variant (`ToolCallObservation`) that lets consumer drivers surface tool activity from wrapped agent frameworks (pi-agent, LangChain, auto-agent loops) to the SDK event stream WITHOUT triggering SDK re-dispatch.

This is the primitive simone called for after my brain L2 bridge PR #353 (the wrapper approach) revealed integrity cost in the pass-through-stub pattern: registry smells, inert permission chain, wrong metrics.

Depends on: all Wish B foundation PRs (#64-#70) merged.

## Motivation

Brain's L2 preservation bridge wraps pi-agent's `runPreservationAgent` as an SDK IterationDriver. Pi-agent owns tool dispatch via `buildPreservationTools`. If the driver yields `tool_call` IterationSteps for each pi-agent `tool_execution_*` event, SDK's runAgent tries to dispatch them again — double execution.

Fallback in PR #353: register 8 preservation tools as throw-stubs. Works but:

| symptom | impact |
|---|---|
| Registry with throw-stubs | "declared but never dispatched" code smell |
| Permission chain inert | SDK claim "runAgent wires permissions for ALL tools" becomes false |
| `metrics.toolCalls = 0` despite N actual calls | Observability compromised |

Per simone's call: ship clean primitive once over papering over repeatedly. This PR is that primitive.

## Contract

New IterationStep kind + event variant:

```ts
type IterationStep =
	| { kind: "tool_call_observation"; tool; args; status; result?; error?; durationMs? }
	| /* existing kinds */;

type AgentEvent =
	| { type: "ToolCallObservation"; timestamp; sessionId; iteration; tool; args; status; result?; error?; durationMs? }
	| /* existing variants */;
```

runAgent guards when it sees an observation step:

| behaviour | why |
|---|---|
| Emits `ToolCallObservation` event (single, discriminated) | Observability preserved. |
| Does NOT emit `ToolCallBefore` / `ToolCallAfter` | Not a dispatch — consumers filtering for dispatched tool calls stay correct. |
| Does NOT invoke the permission chain | Dispatch already happened; the external framework is authoritative. Advisory hooks deferred (see "Deferred" below). |
| Does NOT invoke `toolRegistry` | No re-execution possible. |
| Does NOT increment `metrics.toolCalls` | Stays a dispatch-only counter; consumers diff observed-vs-dispatched separately. |

Status lifecycle (`started` / `completed` / `failed`) is free-form. Drivers can emit one per dispatch or three (begin → end → error) — consumer event stream respects whatever the driver chose.

## Change shape (6 files, +420/-9)

| file | purpose |
|---|---|
| `src/sdk/events.ts` | Add `ToolCallObservationEvent` + `ToolCallObservationStatus` + `AgentEventType` + `ALL_AGENT_EVENT_TYPES` entry. `WISH_SPEC_EVENT_TYPES` untouched (stays 10). |
| `src/sdk/agent.ts` | Add `tool_call_observation` IterationStep kind + runAgent step handler (emits observation event, skips dispatch/permission/registry/metrics). |
| `src/sdk/index.ts` | Re-export new types. |
| `tests/sdk-events.test.ts` | Update `ALL_AGENT_EVENT_TYPES` assertions 12 → 13; JSON round-trip covers new variant. |
| `tests/sdk-tool-call-observation.test.ts` (new, 6 tests) | Dedicated coverage for the guard behaviours. |
| `docs/events.md` | New "Observe-vs-dispatch" section + catalogue table update. |

## Event type accounting

- `WISH_SPEC_EVENT_TYPES` pinned at **10** (contract unchanged).
- `ALL_AGENT_EVENT_TYPES` = **13** (was 12): wish-spec 10 + `SessionOpen` + `SessionClose` (G2) + `ToolCallObservation` (L2a).

## Verification

- `npm run check` (`tsc --noEmit`) → clean
- `npm run build` → ok
- SDK isolated → **141 / 141 pass** across 28 suites
- `npm test` (full) → **346 / 346 pass** (was 340 post-G4; +6 new, zero regression)

## Tests (6 in `sdk-tool-call-observation.test.ts`)

1. Emits `ToolCallObservation` event with all fields populated
2. Does NOT emit `ToolCallBefore` / `ToolCallAfter`
3. Does NOT invoke the tool registry (verified by registering a handler + asserting it was never called)
4. Does NOT invoke the permission chain (verified by registering a hook + asserting zero invocations)
5. Status transitions (started / completed / failed) surface distinctly
6. Observations interleave cleanly with native `message` + `emit_done` steps

## Deferred

- **Advisory permission hooks on observations.** Currently permission chain NEVER fires for observations — strict guard. If a real consumer needs observation-level policy (e.g. "log every external tool that ran but disagree with denials"), we can add a second hook lane later. File-and-forget until then.
- **Observed-tool metrics counter** distinct from dispatch counter. Skip until brain bridge dogfood proves consumer needs the data.

## Unblocks

- **brain L2 bridge rework** — khal-os PR #353 (wrapper approach, currently open as alternative) gets superseded by a follow-up PR using proper 1:1 pi-agent → SDK event mapping via `tool_call_observation`.
- Any future consumer wrapping an external framework whose tool dispatch is already complete.

## Base + head

- Base: `dev` @ `47d08f5`
- Head: `b09692e`
- Branch: `feat/tool-call-observation-step`

## Design question flagged to simone (answer pending)

I went with **option (i)** — new IterationStep kind AND new AgentEvent type, symmetric primitives, consumers filtering observed-vs-dispatched get a clean discriminator. Alternative was (ii) reusing `ToolCallBefore/After` with an `observed: true` flag. Happy to flip to (ii) if reviewer prefers smaller surface. Current PR implements (i).