### PR TITLE
chore(dist): rebuild — exports ToolCallObservationEvent after #72

### DIFF
--- a/dist/src/sdk/agent.d.ts
+++ b/dist/src/sdk/agent.d.ts
@@ -49,6 +49,26 @@ export type IterationStep = {
     readonly tool: string;
     readonly args: unknown;
 } | {
+    /**
+     * Observation of a tool call whose dispatch happened elsewhere
+     * — e.g. inside a wrapped agent framework (pi-agent, LangChain).
+     * runAgent emits a `ToolCallObservation` event with the carried
+     * payload and does NOT invoke the permission chain or the tool
+     * registry. Consumers that want observation-based policy should
+     * subscribe to the event. See `events.ts`
+     * `ToolCallObservationEvent`.
+     */
+    readonly kind: "tool_call_observation";
+    readonly tool: string;
+    readonly args: unknown;
+    readonly status: "started" | "completed" | "failed";
+    readonly result?: unknown;
+    readonly error?: {
+        readonly name: string;
+        readonly message: string;
+    };
+    readonly durationMs?: number;
+} | {
     readonly kind: "emit_done";
     readonly payload: unknown;
 } | {

--- a/dist/src/sdk/agent.js
+++ b/dist/src/sdk/agent.js
@@ -237,6 +237,33 @@ async function drive(config, em) {
                         em.emit(after);
                         continue;
                     }
+                    case "tool_call_observation": {
+                        // Observation: tool dispatch happened OUTSIDE the SDK
+                        // (typically inside a wrapped framework like pi-agent
+                        // or LangChain). runAgent does NOT invoke the
+                        // permission chain or the tool registry. The step
+                        // surfaces as a dedicated `ToolCallObservation` event
+                        // so consumers can distinguish from SDK-dispatched
+                        // tool_call / tool_call_after pairs.
+                        const obs = makeEvent("ToolCallObservation", {
+                            sessionId,
+                            iteration,
+                            tool: step.tool,
+                            args: step.args,
+                            status: step.status,
+                            result: step.result,
+                            error: step.error,
+                            durationMs: step.durationMs,
+                        });
+                        em.emit(obs);
+                        // Count observations distinctly from dispatched tool
+                        // calls — consumer metrics can diff observed vs
+                        // dispatched to understand execution topology.
+                        // (`toolCalls` stays a dispatch-only counter; this
+                        // is tracked separately when the recorder lands a
+                        // `incrObservedCalls` helper.)
+                        continue;
+                    }
                     case "emit_done": {
                         if (validateSchema) {
                             validateAttempt++;

--- a/dist/src/sdk/events.d.ts
+++ b/dist/src/sdk/events.d.ts
@@ -13,7 +13,7 @@
  *
  * Spec source: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L21.
  */
-export type AgentEventType = "AgentStart" | "IterationStart" | "IterationOutput" | "ToolCallBefore" | "ToolCallAfter" | "Recurse" | "Validation" | "Message" | "EmitDone" | "Error" | "SessionOpen" | "SessionClose";
+export type AgentEventType = "AgentStart" | "IterationStart" | "IterationOutput" | "ToolCallBefore" | "ToolCallAfter" | "Recurse" | "Validation" | "Message" | "EmitDone" | "Error" | "SessionOpen" | "SessionClose" | "ToolCallObservation";
 /** Base shape — every event carries a timestamp + discriminant. */
 interface BaseEvent {
     /** ISO-8601 timestamp emitted by `iso()`. */
@@ -139,8 +139,46 @@ export interface SessionCloseEvent extends BaseEvent {
     readonly sessionId: string;
     readonly reason: SessionCloseReason;
 }
+/**
+ * Observation of a tool call whose dispatch happens elsewhere (e.g.
+ * inside a wrapped framework like pi-agent or LangChain). runAgent
+ * emits this when the driver yields a `tool_call_observation`
+ * IterationStep — it does NOT invoke the permission chain or the
+ * tool registry for observations (the external framework already
+ * handled both). Consumers interested in observation-based policy
+ * subscribe to this event directly.
+ *
+ * `status` lifecycle:
+ *   - `"started"` — driver observed the tool call begin
+ *   - `"completed"` — tool returned successfully, `result` present
+ *   - `"failed"` — tool errored, `error` present
+ *
+ * Intended for consumer drivers that wrap an external agent
+ * framework whose tool dispatch is already complete — e.g. brain's
+ * preservation bridge driving pi-agent. Native SDK tool dispatch
+ * (`tool_call` IterationStep) stays the primary path for
+ * consumers authoring loops inside the SDK.
+ */
+export type ToolCallObservationStatus = "started" | "completed" | "failed";
+export interface ToolCallObservationEvent extends BaseEvent {
+    readonly type: "ToolCallObservation";
+    readonly sessionId: string;
+    readonly iteration: number;
+    readonly tool: string;
+    readonly args: unknown;
+    readonly status: ToolCallObservationStatus;
+    readonly result?: unknown;
+    readonly error?: {
+        readonly name: string;
+        readonly message: string;
+    };
+    /** Wall-clock duration of the external dispatch, when the driver
+     *  can report it. Optional — drivers that only surface completion
+     *  may not have timing. */
+    readonly durationMs?: number;
+}
 /** Discriminated union — the sole surface SDK consumers iterate over. */
-export type AgentEvent = AgentStartEvent | IterationStartEvent | IterationOutputEvent | ToolCallBeforeEvent | ToolCallAfterEvent | RecurseEvent | ValidationEvent | MessageEvent | EmitDoneEvent | ErrorEvent | SessionOpenEvent | SessionCloseEvent;
+export type AgentEvent = AgentStartEvent | IterationStartEvent | IterationOutputEvent | ToolCallBeforeEvent | ToolCallAfterEvent | RecurseEvent | ValidationEvent | MessageEvent | EmitDoneEvent | ErrorEvent | SessionOpenEvent | SessionCloseEvent | ToolCallObservationEvent;
 /**
  * Exhaustive sentinel — useful for switch statements so TS flags any
  * consumer that forgets to handle a new variant as the union grows.

--- a/dist/src/sdk/events.js
+++ b/dist/src/sdk/events.js
@@ -15,6 +15,7 @@ export const ALL_AGENT_EVENT_TYPES = [
     "Error",
     "SessionOpen",
     "SessionClose",
+    "ToolCallObservation",
 ];
 /** The 10 wish-spec event types. Session lifecycle types (SessionOpen /
  *  SessionClose) arrive in Group 2 as additions — `ALL_AGENT_EVENT_TYPES`

--- a/dist/src/sdk/index.d.ts
+++ b/dist/src/sdk/index.d.ts
@@ -7,7 +7,7 @@
  * `.genie/wishes/rlmx-sdk-upgrade/WISH.md`.
  */
 export { ALL_AGENT_EVENT_TYPES, WISH_SPEC_EVENT_TYPES, isAgentEvent, iso, makeEvent, } from "./events.js";
-export type { AgentEvent, AgentEventType, AgentStartEvent, EmitDoneEvent, ErrorEvent, IterationOutputEvent, IterationStartEvent, MessageEvent, RecurseEvent, SessionCloseEvent, SessionCloseReason, SessionOpenEvent, ToolCallAfterEvent, ToolCallBeforeEvent, ValidationEvent, } from "./events.js";
+export type { AgentEvent, AgentEventType, AgentStartEvent, EmitDoneEvent, ErrorEvent, IterationOutputEvent, IterationStartEvent, MessageEvent, RecurseEvent, SessionCloseEvent, SessionCloseReason, SessionOpenEvent, ToolCallAfterEvent, ToolCallBeforeEvent, ToolCallObservationEvent, ToolCallObservationStatus, ValidationEvent, } from "./events.js";
 export { createEmitter } from "./emitter.js";
 export type { EmitterAndStream, EventEmitter, EventStream, } from "./emitter.js";
 export { createFileSessionStore, isSessionState, pauseAgent, resumeAgent, } from "./session.js";

--- a/dist/src/version.d.ts
+++ b/dist/src/version.d.ts
@@ -1,2 +1,2 @@
-export declare const VERSION = "0.260422.8";
+export declare const VERSION = "0.260422.10";
 //# sourceMappingURL=version.d.ts.map

--- a/dist/src/version.js
+++ b/dist/src/version.js
@@ -1,2 +1,2 @@
-export const VERSION = '0.260422.8';
+export const VERSION = '0.260422.10';
 //# sourceMappingURL=version.js.map

--- a/dist/tests/sdk-events.test.js
+++ b/dist/tests/sdk-events.test.js
@@ -18,10 +18,14 @@ describe("SDK events — contract (Wish B Groups 1 + 2)", () => {
         assert.deepEqual([...WISH_SPEC_EVENT_TYPES], [...expected], "WISH_SPEC_EVENT_TYPES must match wish spec exactly");
         assert.equal(WISH_SPEC_EVENT_TYPES.length, 10);
     });
-    it("ALL_AGENT_EVENT_TYPES extends the wish spec with session lifecycle (Group 2)", () => {
-        const extras = ["SessionOpen", "SessionClose"];
-        assert.deepEqual([...ALL_AGENT_EVENT_TYPES], [...WISH_SPEC_EVENT_TYPES, ...extras], "ALL_AGENT_EVENT_TYPES = wish-spec 10 + SessionOpen/SessionClose from G2");
-        assert.equal(ALL_AGENT_EVENT_TYPES.length, 12);
+    it("ALL_AGENT_EVENT_TYPES extends the wish spec with session + observation events", () => {
+        const extras = [
+            "SessionOpen",
+            "SessionClose",
+            "ToolCallObservation",
+        ];
+        assert.deepEqual([...ALL_AGENT_EVENT_TYPES], [...WISH_SPEC_EVENT_TYPES, ...extras], "ALL_AGENT_EVENT_TYPES = wish-spec 10 + Session{Open,Close} (G2) + ToolCallObservation (L2a)");
+        assert.equal(ALL_AGENT_EVENT_TYPES.length, 13);
     });
     it("makeEvent fills timestamp + type automatically", () => {
         const ev = makeEvent("IterationStart", {
@@ -106,8 +110,16 @@ describe("SDK events — contract (Wish B Groups 1 + 2)", () => {
                 sessionId: "s1",
                 reason: "complete",
             }),
+            makeEvent("ToolCallObservation", {
+                sessionId: "s1",
+                iteration: 1,
+                tool: "external_tool",
+                args: { q: "?" },
+                status: "completed",
+                result: "ok",
+            }),
         ];
-        assert.equal(samples.length, 12);
+        assert.equal(samples.length, 13);
         for (const ev of samples) {
             const round = JSON.parse(JSON.stringify(ev));
             assert.equal(round.type, ev.type);

--- a/dist/tests/sdk-tool-call-observation.test.d.ts
+++ b/dist/tests/sdk-tool-call-observation.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=sdk-tool-call-observation.test.d.ts.map

--- a/dist/tests/sdk-tool-call-observation.test.js
+++ b/dist/tests/sdk-tool-call-observation.test.js
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createToolRegistry, runAgent, } from "../src/sdk/index.js";
+async function drain(stream) {
+    const events = [];
+    for await (const ev of stream)
+        events.push(ev);
+    return events;
+}
+describe("IterationStep tool_call_observation — observe-vs-dispatch (L2a)", () => {
+    it("emits ToolCallObservation event for an observation step", async () => {
+        const driver = async function* () {
+            yield {
+                kind: "tool_call_observation",
+                tool: "external_tool",
+                args: { q: "?" },
+                status: "completed",
+                result: { ok: true },
+                durationMs: 42,
+            };
+            yield { kind: "emit_done", payload: {} };
+        };
+        const events = await drain(runAgent({
+            agentId: "obs",
+            sessionId: "s-obs",
+            input: "test",
+            driver,
+            maxIterations: 1,
+        }));
+        const obs = events.find((e) => e.type === "ToolCallObservation");
+        assert.ok(obs, "expected ToolCallObservation event");
+        assert.equal(obs?.tool, "external_tool");
+        assert.equal(obs?.status, "completed");
+        assert.deepEqual(obs?.result, { ok: true });
+        assert.equal(obs?.durationMs, 42);
+    });
+    it("does NOT emit ToolCallBefore/After for an observation (no SDK dispatch)", async () => {
+        const driver = async function* () {
+            yield {
+                kind: "tool_call_observation",
+                tool: "external_tool",
+                args: {},
+                status: "completed",
+            };
+            yield { kind: "emit_done", payload: {} };
+        };
+        const events = await drain(runAgent({
+            agentId: "obs-no-dispatch",
+            sessionId: "s",
+            input: "test",
+            driver,
+            maxIterations: 1,
+        }));
+        assert.equal(events.some((e) => e.type === "ToolCallBefore"), false, "observations must not produce ToolCallBefore");
+        assert.equal(events.some((e) => e.type === "ToolCallAfter"), false, "observations must not produce ToolCallAfter");
+    });
+    it("does NOT call the tool registry for an observation (guard check)", async () => {
+        const calls = [];
+        const registry = createToolRegistry();
+        const handler = async (args) => {
+            calls.push(JSON.stringify(args));
+            return "from-registry";
+        };
+        registry.register("external_tool", handler);
+        const driver = async function* () {
+            yield {
+                kind: "tool_call_observation",
+                tool: "external_tool",
+                args: { q: "x" },
+                status: "completed",
+                result: "from-driver",
+            };
+            yield { kind: "emit_done", payload: {} };
+        };
+        await drain(runAgent({
+            agentId: "obs-no-reg",
+            sessionId: "s",
+            input: "test",
+            driver,
+            toolRegistry: registry,
+            maxIterations: 1,
+        }));
+        assert.deepEqual(calls, [], "registry handler must not fire for observations");
+    });
+    it("does NOT invoke the permission chain for an observation (guard check)", async () => {
+        let permissionCalls = 0;
+        const hook = () => {
+            permissionCalls++;
+            return { decision: "deny", reason: "should not be asked" };
+        };
+        const driver = async function* () {
+            yield {
+                kind: "tool_call_observation",
+                tool: "external_tool",
+                args: {},
+                status: "completed",
+            };
+            yield { kind: "emit_done", payload: {} };
+        };
+        await drain(runAgent({
+            agentId: "obs-no-perm",
+            sessionId: "s",
+            input: "test",
+            driver,
+            permissionHooks: [hook],
+            maxIterations: 1,
+        }));
+        assert.equal(permissionCalls, 0, "permission chain must not fire for observations");
+    });
+    it("status transitions (started/completed/failed) surface distinctly", async () => {
+        const driver = async function* () {
+            yield {
+                kind: "tool_call_observation",
+                tool: "t",
+                args: {},
+                status: "started",
+            };
+            yield {
+                kind: "tool_call_observation",
+                tool: "t",
+                args: {},
+                status: "completed",
+                result: "ok",
+            };
+            yield {
+                kind: "tool_call_observation",
+                tool: "t2",
+                args: {},
+                status: "failed",
+                error: { name: "Error", message: "bang" },
+            };
+            yield { kind: "emit_done", payload: {} };
+        };
+        const events = await drain(runAgent({
+            agentId: "obs-status",
+            sessionId: "s",
+            input: "test",
+            driver,
+            maxIterations: 1,
+        }));
+        const observations = events.filter((e) => e.type === "ToolCallObservation");
+        assert.equal(observations.length, 3);
+        assert.equal(observations[0]?.status, "started");
+        assert.equal(observations[1]?.status, "completed");
+        assert.equal(observations[2]?.status, "failed");
+        assert.equal(observations[2]?.error?.message, "bang");
+    });
+    it("observations can interleave with native SDK tool_call + message steps", async () => {
+        const driver = async function* () {
+            yield {
+                kind: "message",
+                role: "assistant",
+                content: "thinking…",
+            };
+            yield {
+                kind: "tool_call_observation",
+                tool: "external",
+                args: {},
+                status: "completed",
+            };
+            yield { kind: "emit_done", payload: {} };
+        };
+        const events = await drain(runAgent({
+            agentId: "obs-mixed",
+            sessionId: "s",
+            input: "test",
+            driver,
+            maxIterations: 1,
+        }));
+        const order = events.map((e) => e.type);
+        // AgentStart, IterationStart, Message, ToolCallObservation, EmitDone,
+        // IterationOutput, SessionClose — exact subset order we care about:
+        const relevant = order.filter((t) => ["Message", "ToolCallObservation", "EmitDone"].includes(t));
+        assert.deepEqual(relevant, [
+            "Message",
+            "ToolCallObservation",
+            "EmitDone",
+        ]);
+    });
+});
+//# sourceMappingURL=sdk-tool-call-observation.test.js.map


### PR DESCRIPTION
## Summary

Post-#72 dist/ was not rebuilt. `ToolCallObservationEvent` / `ToolCallObservationStatus` types and the `"tool_call_observation"` IterationStep kind live in `src/sdk/{agent,events}.ts` from PR #72, but never made it into `dist/`. Consumers importing those names against the published package (L2b brain bridge in flight, future adopters) would fail at resolve time until this rebuild.

## What changed

Pure `bun run build` output diff on top of origin/dev @ `b6c4d90`:

| file | why |
|---|---|
| `dist/src/sdk/agent.d.ts` | adds `"tool_call_observation"` IterationStep kind to the union |
| `dist/src/sdk/agent.js` | handler branch for the new kind |
| `dist/src/sdk/events.d.ts` / `.js` | exports `ToolCallObservationEvent` + `ToolCallObservationStatus` |
| `dist/src/sdk/index.d.ts` | re-exports the two new types |
| `dist/tests/sdk-events.test.js` | rebuilt from updated source |
| `dist/tests/sdk-tool-call-observation.test.{d.ts,js}` | new — was missing entirely |
| `dist/src/version.{d.ts,js}` | 0.260422.8 → 0.260422.10 (source tag) |

**Zero source changes.** No functional drift possible.

## Incidental cleanup

The build script does `cp -r src/templates dist/src/templates`. When `dist/src/templates/` already exists, `cp -r` nests: the result is `dist/src/templates/templates/<files>`. This PR removes the nested duplicate. Fixing the build script (use `rsync -a --delete` or `rm -rf dist/src/templates && cp -r`) is a separate slice.

## Verification

```
grep -c "tool_call_observation" dist/src/sdk/agent.d.ts dist/src/sdk/agent.js
# dist/src/sdk/agent.d.ts:1
# dist/src/sdk/agent.js:1
```

Both `0` before this PR (`#72` source landed without a post-merge rebuild).

## Test plan

- [x] `bun run build` — succeeds
- [x] dist diff matches source-level additions from #72
- [x] New test artifact `sdk-tool-call-observation.test.{d.ts,js}` present
- [x] version.{d.ts,js} matches source version `0.260422.10`
- [x] Incidental `templates/templates/` double-nest removed

## Scope

Chore-only. No API surface change, no runtime behaviour change, just restoring dist ↔ source parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)