### PR TITLE
fix(build): idempotent templates copy — kill nested duplicate (#31)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "examples"
   ],
   "scripts": {
-    "build": "tsc && cp src/benchmark-data.json dist/src/ && cp -r src/templates dist/src/templates",
+    "build": "tsc && cp src/benchmark-data.json dist/src/ && rm -rf dist/src/templates && cp -r src/templates dist/src/templates",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "node --test dist/tests/*.test.js",


### PR DESCRIPTION
## Bug

`npm run build` / `bun run build` runs:
```bash
cp -r src/templates dist/src/templates
```

When `dist/src/templates/` already exists (any rebuild without `npm run clean` first), `cp -r` treats the destination as an existing dir and copies the **source dir INSIDE it**, producing:

```
dist/src/templates/templates/{code,default}   # after 2nd build
dist/src/templates/templates/templates/...    # after 3rd build
```

This breaks downstream consumers that resolve template paths at `dist/src/templates/{code,default}` — and ships nested duplicates inside the published tarball (since `files` includes `dist/src`).

## Fix

```diff
- "build": "tsc && cp src/benchmark-data.json dist/src/ && cp -r src/templates dist/src/templates",
+ "build": "tsc && cp src/benchmark-data.json dist/src/ && rm -rf dist/src/templates && cp -r src/templates dist/src/templates",
```

`rm -rf` before copy makes the step idempotent. Portable, no `rsync` dependency.

## Evidence

**Before (on `dev`, after two builds):**
```
$ find dist/src/templates -type d
dist/src/templates
dist/src/templates/code
dist/src/templates/templates          ← nested duplicate
dist/src/templates/default
dist/src/templates/templates/code
dist/src/templates/templates/default
```

**After (this PR, three consecutive builds):**
```
$ find dist/src/templates -type d
dist/src/templates
dist/src/templates/code
dist/src/templates/default            ← flat, no nesting
```

## Validation

- `bun run build` × 3 consecutive runs → no nesting
- `bun run check` (`tsc --noEmit`) → clean
- `bun run test` → 346/346 pass

Closes #31