### PR TITLE
feat(sdk): tool dispatch in rlmDriver — unblocks tier 2 agents (#78)

### DIFF
--- a/dist/src/sdk/agent.d.ts
+++ b/dist/src/sdk/agent.d.ts
@@ -39,6 +39,26 @@ import type { ToolRegistry } from "./tool-registry.js";
 import { type PermissionHook } from "./permissions.js";
 import { type BudgetSnapshot, type HistoryTurn, type SessionStore } from "./session.js";
 import { type ValidateSchema } from "./validate.js";
+/**
+ * Outcome of a tool_call dispatch, fed back to the driver via
+ * `AsyncGenerator.next(outcome)` so multi-turn drivers (rlmDriver
+ * in tool-dispatch mode, rlmx#78) can fold the result into the
+ * next LLM call as conversation history.
+ */
+export interface ToolCallOutcome {
+    readonly tool: string;
+    readonly ok: boolean;
+    readonly result: unknown;
+    readonly error?: {
+        readonly name: string;
+        readonly message: string;
+    };
+    readonly durationMs: number;
+    /** True when the permission chain denied the call. `result` is null and
+     *  `ok` is false in this case; drivers that want to explain the denial
+     *  to the LLM should surface `error.message` as a tool-result note. */
+    readonly denied?: boolean;
+}
 /** One step produced by an `IterationDriver` during a single iteration. */
 export type IterationStep = {
     readonly kind: "message";
@@ -48,6 +68,11 @@ export type IterationStep = {
     readonly kind: "tool_call";
     readonly tool: string;
     readonly args: unknown;
+    /** Optional LLM-issued id (e.g. Gemini `functionCall.id`,
+     *  Anthropic `tool_use.id`). Drivers that need to pair
+     *  outcomes with ToolResultMessage.toolCallId should set
+     *  this so the outcome comes back correlated. */
+    readonly id?: string;
 } | {
     /**
      * Observation of a tool call whose dispatch happened elsewhere
@@ -83,7 +108,21 @@ export interface IterationRequest {
      *  driver should prepend this to its next model turn. */
     readonly retryHint?: string;
 }
-export type IterationDriver = (req: IterationRequest, signal: AbortSignal) => AsyncIterable<IterationStep>;
+/**
+ * An `IterationDriver` is an async generator that runAgent pumps.
+ *
+ * runAgent uses manual iteration (`iter.next(value)`) so drivers can
+ * receive tool-call outcomes back from runAgent — the generator's
+ * `yield` returns the `ToolCallOutcome` when the previously yielded
+ * step was a `tool_call` and runAgent finished dispatching it. For
+ * any other step kind (message, emit_done, error,
+ * tool_call_observation) the yield returns `undefined`.
+ *
+ * Drivers that don't care about tool outcomes (e.g. the legacy
+ * one-shot rlmDriver path) can just `yield step` and ignore the
+ * return value — behavior is unchanged from the pre-rlmx#78 contract.
+ */
+export type IterationDriver = (req: IterationRequest, signal: AbortSignal) => AsyncIterable<IterationStep> | AsyncGenerator<IterationStep, void, ToolCallOutcome | undefined>;
 /** Resolves a tool invocation. Called after a non-deny permission
  *  decision. When omitted, tool calls are recorded but not executed
  *  (the `ToolCallAfter.result` is `null`). */

--- a/dist/src/sdk/agent.js
+++ b/dist/src/sdk/agent.js
@@ -146,7 +146,26 @@ async function drive(config, em) {
                 retryHint,
             };
             let iterOutput = "";
-            for await (const step of driver(req, ac.signal)) {
+            // Manual iteration so we can push tool outcomes back into the
+            // driver via `.next(outcome)`. Async generators treat a call
+            // to `.next(value)` as the return value of the current `yield`,
+            // which is how multi-turn drivers (rlmDriver in tool-dispatch
+            // mode) fold tool results back into the next LLM call.
+            const iter = driver(req, ac.signal);
+            let nextInput;
+            while (true) {
+                if (ac.signal.aborted)
+                    break iterationLoop;
+                const { value: step, done: iterDone } = await iter.next(nextInput);
+                nextInput = undefined;
+                if (iterDone)
+                    break;
+                if (!step)
+                    continue;
+                // Re-check abort AFTER the driver yielded — the driver
+                // itself may have triggered the abort in its yield
+                // prelude. Matches the pre-rlmx#78 `for await` semantics
+                // which checked before processing each step.
                 if (ac.signal.aborted)
                     break iterationLoop;
                 switch (step.kind) {
@@ -203,11 +222,26 @@ async function drive(config, em) {
                                 },
                             });
                             em.emit(err);
+                            // Surface the denial to the driver so it can
+                            // explain the failure back to the LLM instead
+                            // of looping forever re-issuing the call.
+                            nextInput = {
+                                tool: step.tool,
+                                ok: false,
+                                result: null,
+                                error: {
+                                    name: "PermissionDenied",
+                                    message: decision.reason,
+                                },
+                                durationMs: 0,
+                                denied: true,
+                            };
                             continue;
                         }
                         const t0 = Date.now();
                         let result = null;
                         let ok = true;
+                        let toolError;
                         try {
                             if (toolRegistry || toolResolver) {
                                 result = await dispatchTool(step.tool, effectiveArgs, ac.signal);
@@ -215,26 +249,37 @@ async function drive(config, em) {
                         }
                         catch (e) {
                             ok = false;
-                            result = e instanceof Error ? e.message : String(e);
+                            toolError = e instanceof Error ? e : new Error(String(e));
+                            result = toolError.message;
                             const err = makeEvent("Error", {
                                 sessionId,
                                 phase: "tool",
                                 error: {
-                                    name: e instanceof Error ? e.name : "Error",
-                                    message: e instanceof Error ? e.message : String(e),
+                                    name: toolError.name,
+                                    message: toolError.message,
                                 },
                             });
                             em.emit(err);
                         }
+                        const durationMs = Date.now() - t0;
                         const after = makeEvent("ToolCallAfter", {
                             sessionId,
                             iteration,
                             tool: step.tool,
                             result,
-                            durationMs: Date.now() - t0,
+                            durationMs,
                             ok,
                         });
                         em.emit(after);
+                        nextInput = {
+                            tool: step.tool,
+                            ok,
+                            result,
+                            error: toolError
+                                ? { name: toolError.name, message: toolError.message }
+                                : undefined,
+                            durationMs,
+                        };
                         continue;
                     }
                     case "tool_call_observation": {

--- a/dist/src/sdk/index.d.ts
+++ b/dist/src/sdk/index.d.ts
@@ -17,13 +17,13 @@ export type { PermissionDecision, PermissionHook, PermissionHookContext, } from 
 export { MAX_VALIDATE_ATTEMPTS, buildRetryHint, parseValidateMd, shouldRetry, validateAgainstSchema, } from "./validate.js";
 export type { ValidateResult, ValidateSchema } from "./validate.js";
 export { runAgent } from "./agent.js";
-export type { AgentConfig, IterationDriver, IterationRequest, IterationStep, ToolResolver, } from "./agent.js";
+export type { AgentConfig, IterationDriver, IterationRequest, IterationStep, ToolCallOutcome, ToolResolver, } from "./agent.js";
 export { formatRlmPrompt, rlmDriver } from "./rlm-driver.js";
-export type { RlmDriverConfig } from "./rlm-driver.js";
+export type { RlmDriverConfig, RlmDriverToolsConfig, } from "./rlm-driver.js";
 export { loadAgentSpec, parseAgentSpec, resolveAgentPath, } from "./agent-spec.js";
 export type { AgentBudget, AgentScope, AgentSpec } from "./agent-spec.js";
 export { createToolRegistry, toolRegistryAsResolver, UnknownToolError, } from "./tool-registry.js";
-export type { ToolContext, ToolHandler, ToolRegistry } from "./tool-registry.js";
+export type { ToolContext, ToolHandler, ToolRegistry, ToolSchema } from "./tool-registry.js";
 export { InvalidPluginError, MissingPluginError, loadPluginTools, } from "./tool-loader.js";
 export type { LoadOptions, LoadResult } from "./tool-loader.js";
 export { registerRtkTool } from "./rtk-plugin.js";

--- a/dist/src/sdk/index.js
+++ b/dist/src/sdk/index.js
@@ -18,7 +18,7 @@ export { ALLOW, composeHooks, runPermissionChain } from "./permissions.js";
 export { MAX_VALIDATE_ATTEMPTS, buildRetryHint, parseValidateMd, shouldRetry, validateAgainstSchema, } from "./validate.js";
 // ─── runAgent (G2b) ──────────────────────────────────────────────
 export { runAgent } from "./agent.js";
-// ─── rlmDriver (G2c — real LLM bridge) ───────────────────────────
+// ─── rlmDriver (G2c — real LLM bridge + rlmx#78 tool dispatch) ───
 export { formatRlmPrompt, rlmDriver } from "./rlm-driver.js";
 // ─── Agent spec + tool plugin loader (G3a) ───────────────────────
 export { loadAgentSpec, parseAgentSpec, resolveAgentPath, } from "./agent-spec.js";

--- a/dist/src/sdk/rlm-driver.d.ts
+++ b/dist/src/sdk/rlm-driver.d.ts
@@ -1,45 +1,106 @@
 /**
- * rlm-driver — Wish B Group 2b/c.
+ * rlm-driver — Wish B Group 2b/c + rlmx#78.
  *
- * Adapts the rlmx LLM backend (`llmCompleteSimple` from `src/llm.ts`)
- * to the `IterationDriver` contract defined in `src/sdk/agent.ts`.
- * Lets `runAgent()` drive a real LLM end-to-end so permissions,
- * validate, session, and events tick through with production-shaped
- * responses instead of canned fixtures.
+ * Adapts the rlmx LLM backend to the `IterationDriver` contract
+ * defined in `src/sdk/agent.ts`. Two modes:
+ *
+ *   1. **Legacy one-shot mode** (no `tools` config) — the original
+ *      behavior: one `llmCompleteSimple` call per iteration, whole
+ *      response surfaced as `emit_done.payload.answer`. Preserved
+ *      byte-compatibly so existing consumers (cli cutover, simple
+ *      agents without tools) keep working.
+ *
+ *   2. **Tool-dispatch mode** (rlmx#78, `tools` config present) —
+ *      multi-turn conversation loop with native function-calling:
+ *
+ *        • ToolRegistry schemas → pi-ai `Tool[]` → provider-native
+ *          function declarations (Gemini functionDeclarations,
+ *          Anthropic tools, OpenAI functions — pi-ai handles the
+ *          per-provider shape).
+ *        • Each LLM call is followed by a check for `ToolCall`
+ *          content blocks; any that are present are yielded as
+ *          `tool_call` steps, their outcomes come back via
+ *          `yield`'s return value (runAgent manual-iterates), and
+ *          we append a `toolResult` message to the pi-ai history
+ *          before the next call.
+ *        • Loop terminates when the LLM emits a pure-text
+ *          response (stopReason === "stop") OR an explicit
+ *          `emit_done` tool call OR the max-tool-iterations cap
+ *          is hit.
+ *        • runAgent's permission chain, validate retry pipeline,
+ *          session/checkpoint primitives all continue to fire —
+ *          the driver stays hermetic and the event flow is
+ *          identical to the G2b contract.
  *
  * Design constraints:
  *
  *   • Zero touch to `src/rlm.ts` — the existing CLI entry (`rlmLoop`)
  *     stays byte-for-byte unchanged. This module is additive.
- *   • Shares the same LLM transport (`llmCompleteSimple`) rlm.ts uses,
- *     so any provider / thinking-level / budget work that lands in
+ *   • Legacy path still shares `llmCompleteSimple` with rlm.ts, so
+ *     any provider / thinking-level / budget work that lands in
  *     `llm.ts` automatically benefits this driver.
- *   • Keeps the surface minimal: one LLM call per iteration, full
- *     response surfaced as a `Message` event, terminal `emit_done`
- *     with the response as payload. Parsing `rlmx`-specific Python
- *     tool-call code blocks is deliberately NOT done here — that's a
- *     larger slice that also requires a REPL executor. This driver
- *     proves the wiring; a follow-up can layer tool dispatch on top.
+ *   • Tool-dispatch path calls pi-ai `completeSimple` directly —
+ *     the tool-aware plumbing (Context.tools, ToolResultMessage,
+ *     preserving AssistantMessage across turns) is inherent to
+ *     pi-ai's transport layer, so we bypass the legacy `llm.ts`
+ *     wrapper rather than bolt tool support on there.
+ *   • Python REPL tool-call parsing (rlmx-specific ```tool_call``` code
+ *     blocks) is still NOT done here — that's the rlm.ts CLI's
+ *     concern and a separate slice. This driver does NATIVE
+ *     function-calling only, which is what Tier 2 brain-consuming
+ *     agents need.
  *
- * Consumers compose it via `runAgent({ driver: rlmDriver(cfg) })` —
- * never called directly by user code.
+ * Consumers compose it via `runAgent({ driver: rlmDriver(cfg),
+ * toolRegistry: registry })` — never called directly by user code.
  *
  * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L93 (wave 5
  * dogfood), plus the "prove end-to-end wiring against real LLM"
- * mandate added in the G2b review cycle.
+ * mandate added in the G2b review cycle; rlmx#78 for the native
+ * tool-dispatch loop that unblocks Tier 2 agents.
  */
+import type { AssistantMessage as PiAssistantMessage, Context as PiContext } from "@mariozechner/pi-ai";
 import type { ModelConfig } from "../config.js";
 import { type LLMResponse } from "../llm.js";
 import type { IterationDriver, IterationRequest } from "./agent.js";
+import type { ToolRegistry } from "./tool-registry.js";
+/**
+ * Tool-dispatch config for rlmx#78. When present on `RlmDriverConfig`,
+ * the driver enters multi-turn tool-dispatch mode.
+ */
+export interface RlmDriverToolsConfig {
+    /** Source of tool schemas the LLM will be offered. Must have at
+     *  least one tool with a schema (via `registry.register(name,
+     *  handler, schema)`) — otherwise the driver falls back to
+     *  one-shot mode for safety. */
+    readonly registry: ToolRegistry;
+    /**
+     * Hard cap on LLM calls per iteration (defense against infinite
+     * tool-calling loops). When exceeded, the driver yields an
+     * `error` step with the partial answer. Default: 16.
+     */
+    readonly maxToolIterations?: number;
+    /**
+     * Optional list of tool names to expose to the LLM. When
+     * omitted, every registry tool with a schema is exposed. Useful
+     * when the agent.yaml whitelist is stricter than the registry
+     * (e.g. RTK pre-registered tools you don't want this agent to
+     * see). Order is preserved in the tools[] array.
+     */
+    readonly expose?: readonly string[];
+}
 export interface RlmDriverConfig {
     /** Model config — same shape rlm.ts uses. */
     readonly model: ModelConfig;
     /** Optional SYSTEM.md contents; prepended to each turn's prompt. */
     readonly system?: string;
     /**
-     * Injectable LLM completion fn. Defaults to the real
-     * `llmCompleteSimple` so production just calls Gemini. Tests pass a
-     * mock to validate the driver's event sequence without a live model.
+     * Injectable LLM completion fn for the legacy (no-tools) path.
+     * Defaults to the real `llmCompleteSimple` so production just
+     * calls Gemini. Tests pass a mock to validate the driver's event
+     * sequence without a live model. Ignored when `tools` is set —
+     * the tool-dispatch path needs pi-ai's native `completeSimple`
+     * for tool-aware transport, and exposes a separate `toolsLlm`
+     * injection point for tests.
      */
     readonly llm?: (prompt: string, modelConfig: ModelConfig, signal?: AbortSignal) => Promise<LLMResponse>;
     /**
@@ -49,6 +110,18 @@ export interface RlmDriverConfig {
      * labelled block.
      */
     readonly retryHintFormatter?: (hint: string) => string;
+    /**
+     * Tool-dispatch config (rlmx#78). When set, switches the driver
+     * into multi-turn native-function-calling mode.
+     */
+    readonly tools?: RlmDriverToolsConfig;
+    /**
+     * Injectable pi-ai completion fn for the tool-dispatch path.
+     * Defaults to the real `completeSimple` so production just calls
+     * Gemini / Anthropic / OpenAI with native function-calling. Tests
+     * pass a mock to validate the tool loop without a live model.
+     */
+    readonly toolsLlm?: (context: PiContext, modelConfig: ModelConfig, signal?: AbortSignal) => Promise<PiAssistantMessage>;
 }
 /**
  * Render the iteration's prompt. Keeps it intentionally simple — the
@@ -59,14 +132,9 @@ export interface RlmDriverConfig {
  */
 export declare function formatRlmPrompt(config: RlmDriverConfig, req: IterationRequest): string;
 /**
- * Build an `IterationDriver` that drives one LLM call per iteration.
- * The returned async generator yields a single `message` step with the
- * full response text followed by an `emit_done` step carrying the
- * response as a structured payload: `{ answer: string; usage: UsageStats }`.
- *
- * When the LLM fails (throws, or returns an empty string), the driver
- * yields an `error` step so `runAgent` can surface it as `Error{phase:"driver"}`
- * and close the session with `reason: "error"`.
+ * Build an `IterationDriver` that drives the LLM. Legacy one-shot
+ * mode when `tools` is absent; multi-turn tool-dispatch mode (rlmx#78)
+ * when `tools` is present and the registry has at least one schema.
  */
 export declare function rlmDriver(config: RlmDriverConfig): IterationDriver;
 //# sourceMappingURL=rlm-driver.d.ts.map

--- a/dist/src/sdk/rlm-driver.js
+++ b/dist/src/sdk/rlm-driver.js
@@ -1,35 +1,67 @@
 /**
- * rlm-driver — Wish B Group 2b/c.
+ * rlm-driver — Wish B Group 2b/c + rlmx#78.
  *
- * Adapts the rlmx LLM backend (`llmCompleteSimple` from `src/llm.ts`)
- * to the `IterationDriver` contract defined in `src/sdk/agent.ts`.
- * Lets `runAgent()` drive a real LLM end-to-end so permissions,
- * validate, session, and events tick through with production-shaped
- * responses instead of canned fixtures.
+ * Adapts the rlmx LLM backend to the `IterationDriver` contract
+ * defined in `src/sdk/agent.ts`. Two modes:
+ *
+ *   1. **Legacy one-shot mode** (no `tools` config) — the original
+ *      behavior: one `llmCompleteSimple` call per iteration, whole
+ *      response surfaced as `emit_done.payload.answer`. Preserved
+ *      byte-compatibly so existing consumers (cli cutover, simple
+ *      agents without tools) keep working.
+ *
+ *   2. **Tool-dispatch mode** (rlmx#78, `tools` config present) —
+ *      multi-turn conversation loop with native function-calling:
+ *
+ *        • ToolRegistry schemas → pi-ai `Tool[]` → provider-native
+ *          function declarations (Gemini functionDeclarations,
+ *          Anthropic tools, OpenAI functions — pi-ai handles the
+ *          per-provider shape).
+ *        • Each LLM call is followed by a check for `ToolCall`
+ *          content blocks; any that are present are yielded as
+ *          `tool_call` steps, their outcomes come back via
+ *          `yield`'s return value (runAgent manual-iterates), and
+ *          we append a `toolResult` message to the pi-ai history
+ *          before the next call.
+ *        • Loop terminates when the LLM emits a pure-text
+ *          response (stopReason === "stop") OR an explicit
+ *          `emit_done` tool call OR the max-tool-iterations cap
+ *          is hit.
+ *        • runAgent's permission chain, validate retry pipeline,
+ *          session/checkpoint primitives all continue to fire —
+ *          the driver stays hermetic and the event flow is
+ *          identical to the G2b contract.
  *
  * Design constraints:
  *
  *   • Zero touch to `src/rlm.ts` — the existing CLI entry (`rlmLoop`)
  *     stays byte-for-byte unchanged. This module is additive.
- *   • Shares the same LLM transport (`llmCompleteSimple`) rlm.ts uses,
- *     so any provider / thinking-level / budget work that lands in
+ *   • Legacy path still shares `llmCompleteSimple` with rlm.ts, so
+ *     any provider / thinking-level / budget work that lands in
  *     `llm.ts` automatically benefits this driver.
- *   • Keeps the surface minimal: one LLM call per iteration, full
- *     response surfaced as a `Message` event, terminal `emit_done`
- *     with the response as payload. Parsing `rlmx`-specific Python
- *     tool-call code blocks is deliberately NOT done here — that's a
- *     larger slice that also requires a REPL executor. This driver
- *     proves the wiring; a follow-up can layer tool dispatch on top.
+ *   • Tool-dispatch path calls pi-ai `completeSimple` directly —
+ *     the tool-aware plumbing (Context.tools, ToolResultMessage,
+ *     preserving AssistantMessage across turns) is inherent to
+ *     pi-ai's transport layer, so we bypass the legacy `llm.ts`
+ *     wrapper rather than bolt tool support on there.
+ *   • Python REPL tool-call parsing (rlmx-specific ```tool_call``` code
+ *     blocks) is still NOT done here — that's the rlm.ts CLI's
+ *     concern and a separate slice. This driver does NATIVE
+ *     function-calling only, which is what Tier 2 brain-consuming
+ *     agents need.
  *
- * Consumers compose it via `runAgent({ driver: rlmDriver(cfg) })` —
- * never called directly by user code.
+ * Consumers compose it via `runAgent({ driver: rlmDriver(cfg),
+ * toolRegistry: registry })` — never called directly by user code.
  *
  * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L93 (wave 5
  * dogfood), plus the "prove end-to-end wiring against real LLM"
- * mandate added in the G2b review cycle.
+ * mandate added in the G2b review cycle; rlmx#78 for the native
+ * tool-dispatch loop that unblocks Tier 2 agents.
  */
+import { completeSimple as piCompleteSimple, getModel as piGetModel, } from "@mariozechner/pi-ai";
 import { llmCompleteSimple } from "../llm.js";
 const DEFAULT_RETRY_FORMATTER = (hint) => `# Retry hint from the validator\n\n${hint}\n\n`;
+const DEFAULT_MAX_TOOL_ITERATIONS = 16;
 /**
  * Render the iteration's prompt. Keeps it intentionally simple — the
  * driver's job is to get a response surface, not to reproduce the
@@ -61,16 +93,83 @@ export function formatRlmPrompt(config, req) {
     return parts.join("\n\n");
 }
 /**
- * Build an `IterationDriver` that drives one LLM call per iteration.
- * The returned async generator yields a single `message` step with the
- * full response text followed by an `emit_done` step carrying the
- * response as a structured payload: `{ answer: string; usage: UsageStats }`.
- *
- * When the LLM fails (throws, or returns an empty string), the driver
- * yields an `error` step so `runAgent` can surface it as `Error{phase:"driver"}`
- * and close the session with `reason: "error"`.
+ * Resolve a pi-ai Model using the same fallback strategy as llm.ts
+ * (try exact id, then strip date suffix). Kept in-sync with `llm.ts`
+ * `resolveModel` — when that helper goes public we'll import it.
+ */
+function resolvePiModel(provider, modelId) {
+    let model = piGetModel(provider, modelId);
+    if (!model) {
+        const stripped = modelId.replace(/-\d{8}$/, "");
+        if (stripped !== modelId) {
+            model = piGetModel(provider, stripped);
+        }
+    }
+    if (!model) {
+        throw new Error(`rlmDriver: unknown model "${modelId}" for provider "${provider}".`);
+    }
+    return model;
+}
+/**
+ * Turn a ToolRegistry + optional allowlist into pi-ai `Tool[]`. Tools
+ * without schemas are skipped (can't be called by the LLM).
+ */
+function buildPiTools(cfg) {
+    const allowed = cfg.expose ? new Set(cfg.expose) : null;
+    const out = [];
+    for (const { name, schema } of cfg.registry.listSchemas()) {
+        if (allowed && !allowed.has(name))
+            continue;
+        out.push(toPiTool(name, schema));
+    }
+    if (allowed) {
+        // Preserve declared order from `expose` when it's set.
+        out.sort((a, b) => {
+            const ia = cfg.expose?.indexOf(a.name) ?? 0;
+            const ib = cfg.expose?.indexOf(b.name) ?? 0;
+            return ia - ib;
+        });
+    }
+    return out;
+}
+function toPiTool(name, schema) {
+    // pi-ai's `parameters` field expects a TSchema (typebox), but at
+    // runtime it just needs a JSON-Schema-shaped object. Cast at the
+    // boundary — the schema travels opaquely through pi-ai's
+    // per-provider converters (e.g. convertTools in google-shared.ts
+    // accepts `parametersJsonSchema`).
+    const parameters = (schema.parameters ?? {
+        type: "object",
+        properties: {},
+    });
+    return {
+        name,
+        description: schema.description ?? "",
+        parameters,
+    };
+}
+/**
+ * Build an `IterationDriver` that drives the LLM. Legacy one-shot
+ * mode when `tools` is absent; multi-turn tool-dispatch mode (rlmx#78)
+ * when `tools` is present and the registry has at least one schema.
  */
 export function rlmDriver(config) {
+    // Pick the branch at driver-construction time so runtime doesn't
+    // re-decide per iteration. The returned generator is hermetic:
+    // both branches satisfy `AsyncGenerator<IterationStep, void,
+    // ToolCallOutcome | undefined>`.
+    if (config.tools && config.tools.registry.listSchemas().length > 0) {
+        return buildToolDispatchDriver(config, config.tools);
+    }
+    return buildLegacyDriver(config);
+}
+/**
+ * Legacy one-shot driver — preserved byte-compatibly from the pre-rlmx#78
+ * rlmDriver so existing tests + consumers keep passing. Yields a single
+ * `message` step with the full response text followed by an `emit_done`
+ * step carrying `{answer, usage, iteration}`.
+ */
+function buildLegacyDriver(config) {
     const llm = config.llm ?? llmCompleteSimple;
     return async function* (req, signal) {
         const prompt = formatRlmPrompt(config, req);
@@ -103,5 +202,272 @@ export function rlmDriver(config) {
             },
         };
     };
+}
+/**
+ * Tool-dispatch driver (rlmx#78). Multi-turn loop that:
+ *   1. seeds the pi-ai Context with systemPrompt + user input
+ *      (+ any retryHint),
+ *   2. calls pi-ai completeSimple with tools=<registry schemas>,
+ *   3. inspects the response for ToolCall blocks, yields a
+ *      `tool_call` step per block, awaits the outcome from runAgent
+ *      via `yield`'s return value,
+ *   4. appends ToolResultMessage(s) + the AssistantMessage to the
+ *      conversation history,
+ *   5. repeats until the model emits a pure-text response
+ *      (stopReason === "stop") or the max-tool-iterations cap trips.
+ *
+ * Final text answer → `message` + `emit_done({answer, usage,
+ * iteration, toolCalls})`. When the LLM explicitly invokes an
+ * `emit_done` tool (if registered), its args become the payload.
+ */
+function buildToolDispatchDriver(config, toolsCfg) {
+    const maxToolIterations = toolsCfg.maxToolIterations ?? DEFAULT_MAX_TOOL_ITERATIONS;
+    const tools = buildPiTools(toolsCfg);
+    const llm = config.toolsLlm ??
+        (async (ctx, modelCfg, signal) => {
+            const model = resolvePiModel(modelCfg.provider, modelCfg.model);
+            const opts = { signal };
+            return await piCompleteSimple(model, ctx, opts);
+        });
+    return async function* (req, signal) {
+        // Seed the conversation history from runAgent's `req.history`
+        // (user input + any prior assistant turns runAgent already
+        // validated) + the retry hint (if present).
+        const piMessages = [];
+        for (const turn of req.history) {
+            if (turn.role === "user" || turn.role === "system") {
+                piMessages.push({
+                    role: "user",
+                    content: turn.content,
+                    timestamp: Date.now(),
+                });
+            }
+            else {
+                // Assistant turns from history are text-only (runAgent
+                // doesn't reconstruct ToolCall blocks across iterations).
+                // Replay them as a minimal AssistantMessage so pi-ai's
+                // per-provider transforms treat them as valid turns.
+                piMessages.push({
+                    role: "assistant",
+                    content: [{ type: "text", text: turn.content }],
+                    api: "anthropic-messages",
+                    provider: config.model.provider,
+                    model: config.model.model,
+                    usage: {
+                        input: 0,
+                        output: 0,
+                        cacheRead: 0,
+                        cacheWrite: 0,
+                        totalTokens: 0,
+                        cost: {
+                            input: 0,
+                            output: 0,
+                            cacheRead: 0,
+                            cacheWrite: 0,
+                            total: 0,
+                        },
+                    },
+                    stopReason: "stop",
+                    timestamp: Date.now(),
+                });
+            }
+        }
+        const systemPrompt = buildSystemPrompt(config, req);
+        let aggregatedText = "";
+        let toolCallsDispatched = 0;
+        let lastUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+        for (let loopIter = 0; loopIter < maxToolIterations; loopIter++) {
+            if (signal.aborted)
+                return;
+            const ctx = {
+                systemPrompt,
+                messages: piMessages,
+                tools,
+            };
+            let assistant;
+            try {
+                assistant = await llm(ctx, config.model, signal);
+            }
+            catch (err) {
+                yield {
+                    kind: "error",
+                    error: err instanceof Error ? err : new Error(String(err)),
+                };
+                return;
+            }
+            // Accumulate usage across tool loop iterations so the final
+            // emit_done payload reflects the full turn, not just the
+            // last LLM call.
+            if (assistant.usage) {
+                lastUsage = {
+                    input: lastUsage.input + (assistant.usage.input ?? 0),
+                    output: lastUsage.output + (assistant.usage.output ?? 0),
+                    cacheRead: lastUsage.cacheRead + (assistant.usage.cacheRead ?? 0),
+                    cacheWrite: lastUsage.cacheWrite + (assistant.usage.cacheWrite ?? 0),
+                    total: lastUsage.total +
+                        (assistant.usage.cost?.total ?? 0),
+                };
+            }
+            // Append the assistant turn to history BEFORE yielding tool
+            // results — pi-ai's next call expects the toolCall blocks
+            // to reference the prior AssistantMessage, not floating
+            // ToolResultMessages.
+            piMessages.push(assistant);
+            const textBlocks = [];
+            const toolCalls = [];
+            for (const block of assistant.content ?? []) {
+                if (block.type === "text") {
+                    textBlocks.push(block.text);
+                }
+                else if (block.type === "toolCall") {
+                    toolCalls.push(block);
+                }
+                // thinking/thoughtSignature blocks are passed through via
+                // piMessages (they live on the AssistantMessage we
+                // already pushed) — the driver doesn't need to surface
+                // them as runAgent events in this PR.
+            }
+            const text = textBlocks.join("").trim();
+            if (text.length > 0) {
+                // Surface interim assistant text as a Message event so
+                // observers (logs, UI) see reasoning between tool calls.
+                yield { kind: "message", role: "assistant", content: text };
+                aggregatedText = text;
+            }
+            if (toolCalls.length === 0) {
+                // Pure text response → terminal. stopReason should be
+                // "stop" here; "length" / "error" get surfaced as
+                // errors.
+                if (assistant.stopReason === "error" || assistant.stopReason === "aborted") {
+                    yield {
+                        kind: "error",
+                        error: new Error(`rlmDriver: LLM stopped with reason "${assistant.stopReason}": ${assistant.errorMessage ?? "<no message>"}`),
+                    };
+                    return;
+                }
+                if (text.length === 0) {
+                    yield {
+                        kind: "error",
+                        error: new Error("rlmDriver: LLM returned empty response (no text, no tool calls)"),
+                    };
+                    return;
+                }
+                yield {
+                    kind: "emit_done",
+                    payload: {
+                        answer: aggregatedText,
+                        usage: lastUsage,
+                        iteration: req.iteration,
+                        toolCalls: toolCallsDispatched,
+                    },
+                };
+                return;
+            }
+            // Dispatch each tool call sequentially. Sequential dispatch
+            // is safer than parallel (permission hooks may mutate
+            // session state, validate cap assumes ordered replay) and
+            // matches the Gemini / Anthropic reference flow.
+            const results = [];
+            for (const tc of toolCalls) {
+                if (signal.aborted)
+                    return;
+                // Special-case an `emit_done` tool call: when an agent
+                // wants to stop with structured output, it calls
+                // emit_done(payload) rather than returning free text.
+                // We honor this directly — no need to re-loop the
+                // LLM.
+                if (tc.name === "emit_done") {
+                    yield {
+                        kind: "emit_done",
+                        payload: tc.arguments,
+                    };
+                    return;
+                }
+                const outcome = yield {
+                    kind: "tool_call",
+                    tool: tc.name,
+                    args: tc.arguments,
+                    id: tc.id,
+                };
+                toolCallsDispatched++;
+                // When runAgent dispatched the call, it returns an
+                // outcome via `.next(outcome)` — the return value of
+                // the `yield`. When runAgent was invoked without a
+                // registry/resolver (unit tests that only check the
+                // step sequence), outcome is undefined; substitute a
+                // benign "nothing happened" placeholder so the driver
+                // can continue gracefully.
+                const safeOutcome = outcome ?? {
+                    tool: tc.name,
+                    ok: true,
+                    result: null,
+                    durationMs: 0,
+                };
+                results.push(buildToolResult(tc, safeOutcome));
+            }
+            // Feed every tool result back in one batch so the next LLM
+            // call sees all outcomes at once. pi-ai / Gemini / Anthropic
+            // all accept interleaved toolResult messages before the
+            // next assistant turn.
+            piMessages.push(...results);
+        }
+        // Fell off the loop → exceeded max-tool-iterations cap. Surface
+        // the last accumulated text as an emit_done so consumers don't
+        // lose partial progress, but annotate via error so budget /
+        // alerting plumbing fires.
+        yield {
+            kind: "error",
+            error: new Error(`rlmDriver: exceeded maxToolIterations=${maxToolIterations} without a terminal response`),
+        };
+    };
+}
+/**
+ * Build the systemPrompt for tool-dispatch mode. Combines the
+ * caller-provided `config.system` with any runAgent-supplied retry
+ * hint so the LLM sees both.
+ */
+function buildSystemPrompt(config, req) {
+    const parts = [];
+    if (config.system)
+        parts.push(config.system.trim());
+    if (req.retryHint && req.retryHint.length > 0) {
+        const formatter = config.retryHintFormatter ?? DEFAULT_RETRY_FORMATTER;
+        parts.push(formatter(req.retryHint).trim());
+    }
+    if (parts.length === 0)
+        return undefined;
+    return parts.join("\n\n");
+}
+/**
+ * Build a pi-ai ToolResultMessage from a ToolCallOutcome + the
+ * original ToolCall. Encodes success results as JSON text so the
+ * LLM sees structured data; errors come through as text with an
+ * "Error:" prefix and `isError: true` so providers that support
+ * tool-error markers (Anthropic) can flag them.
+ */
+function buildToolResult(tc, outcome) {
+    const resultText = outcome.ok
+        ? formatResultText(outcome.result)
+        : `Error: ${outcome.error?.message ?? String(outcome.result)}`;
+    return {
+        role: "toolResult",
+        toolCallId: tc.id,
+        toolName: tc.name,
+        content: [{ type: "text", text: resultText }],
+        isError: !outcome.ok,
+        timestamp: Date.now(),
+    };
+}
+function formatResultText(result) {
+    if (typeof result === "string")
+        return result;
+    if (result === null || result === undefined)
+        return "";
+    try {
+        return JSON.stringify(result);
+    }
+    catch {
+        return String(result);
+    }
 }
 //# sourceMappingURL=rlm-driver.js.map

--- a/dist/src/sdk/tool-registry.d.ts
+++ b/dist/src/sdk/tool-registry.d.ts
@@ -1,5 +1,5 @@
 /**
- * Tool registry — Wish B Group 3a.
+ * Tool registry — Wish B Group 3a + rlmx#78.
  *
  * Maps tool names declared in `agent.yaml` (`tools: [...]`) to
  * in-process handler functions the SDK can dispatch to. Both
@@ -7,11 +7,20 @@
  * handlers (TS plugins from `<agent-dir>/tools/<name>.ts`) land in
  * the same registry.
  *
- * The registry is deliberately boring: `register`, `get`, `list`,
- * `has`. Anything richer — permission overlays, timeouts, retries —
- * belongs in the runAgent dispatch path, not here.
+ * Each handler may carry an optional `ToolSchema` (rlmx#78) — the
+ * description + JSON-Schema parameters the rlmDriver feeds into the
+ * LLM's native function-calling channel. Handlers without schemas are
+ * still dispatchable (via explicit `tool_call` steps emitted by a
+ * driver that composes the args another way) but will NOT be exposed
+ * to the LLM as callable functions.
  *
- * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L24, L164-168.
+ * The registry is deliberately boring: `register`, `get`, `list`,
+ * `has`, `describe`, `listSchemas`. Anything richer — permission
+ * overlays, timeouts, retries — belongs in the runAgent dispatch path,
+ * not here.
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L24, L164-168;
+ * rlmx#78 (tool dispatch in rlmDriver).
  */
 import type { ToolResolver } from "./agent.js";
 export interface ToolContext {
@@ -21,13 +30,40 @@ export interface ToolContext {
     readonly signal: AbortSignal;
 }
 export type ToolHandler = (args: unknown, ctx: ToolContext) => Promise<unknown>;
+/**
+ * Optional metadata describing a tool's invocation contract. When
+ * present, the rlmDriver forwards this to the LLM as a native
+ * function-calling tool. When absent, the tool is only dispatchable
+ * via out-of-band mechanisms (e.g. a custom driver that emits
+ * `tool_call` steps with args it sourced itself).
+ *
+ * `parameters` is a plain JSON Schema object — any valid draft-07 /
+ * 2020-12 shape works. pi-ai normalizes this for each provider
+ * (Gemini functionDeclarations, Anthropic input_schema, etc.) so the
+ * same object ships to every backend.
+ */
+export interface ToolSchema {
+    readonly description?: string;
+    readonly parameters?: Record<string, unknown>;
+}
 export interface ToolRegistry {
-    register(name: string, handler: ToolHandler): void;
+    register(name: string, handler: ToolHandler, schema?: ToolSchema): void;
     get(name: string): ToolHandler | undefined;
     has(name: string): boolean;
     list(): readonly string[];
-    /** Replace the handler for a name if it exists; no-op otherwise. */
-    override(name: string, handler: ToolHandler): boolean;
+    /** Replace the handler for a name if it exists; no-op otherwise.
+     *  When `schema` is supplied it replaces the existing one. */
+    override(name: string, handler: ToolHandler, schema?: ToolSchema): boolean;
+    /** Metadata describing how the LLM should call this tool. `undefined`
+     *  when the caller registered a handler without a schema. */
+    describe(name: string): ToolSchema | undefined;
+    /** Snapshot of every `{name, schema}` with a schema attached — the
+     *  list of tools eligible for native function-calling. Tools
+     *  without schemas are omitted. */
+    listSchemas(): readonly {
+        readonly name: string;
+        readonly schema: ToolSchema;
+    }[];
 }
 export declare class UnknownToolError extends Error {
     readonly toolName: string;

--- a/dist/src/sdk/tool-registry.js
+++ b/dist/src/sdk/tool-registry.js
@@ -1,5 +1,5 @@
 /**
- * Tool registry — Wish B Group 3a.
+ * Tool registry — Wish B Group 3a + rlmx#78.
  *
  * Maps tool names declared in `agent.yaml` (`tools: [...]`) to
  * in-process handler functions the SDK can dispatch to. Both
@@ -7,11 +7,20 @@
  * handlers (TS plugins from `<agent-dir>/tools/<name>.ts`) land in
  * the same registry.
  *
- * The registry is deliberately boring: `register`, `get`, `list`,
- * `has`. Anything richer — permission overlays, timeouts, retries —
- * belongs in the runAgent dispatch path, not here.
+ * Each handler may carry an optional `ToolSchema` (rlmx#78) — the
+ * description + JSON-Schema parameters the rlmDriver feeds into the
+ * LLM's native function-calling channel. Handlers without schemas are
+ * still dispatchable (via explicit `tool_call` steps emitted by a
+ * driver that composes the args another way) but will NOT be exposed
+ * to the LLM as callable functions.
  *
- * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L24, L164-168.
+ * The registry is deliberately boring: `register`, `get`, `list`,
+ * `has`, `describe`, `listSchemas`. Anything richer — permission
+ * overlays, timeouts, retries — belongs in the runAgent dispatch path,
+ * not here.
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L24, L164-168;
+ * rlmx#78 (tool dispatch in rlmDriver).
  */
 export class UnknownToolError extends Error {
     toolName;
@@ -24,12 +33,15 @@ export class UnknownToolError extends Error {
 /** Create a fresh in-memory tool registry. Simple Map under the hood. */
 export function createToolRegistry() {
     const handlers = new Map();
+    const schemas = new Map();
     return {
-        register(name, handler) {
+        register(name, handler, schema) {
             if (name.length === 0) {
                 throw new TypeError("tool registry: name must be non-empty");
             }
             handlers.set(name, handler);
+            if (schema)
+                schemas.set(name, schema);
         },
         get(name) {
             return handlers.get(name);
@@ -40,11 +52,25 @@ export function createToolRegistry() {
         list() {
             return [...handlers.keys()];
         },
-        override(name, handler) {
+        override(name, handler, schema) {
             if (!handlers.has(name))
                 return false;
             handlers.set(name, handler);
+            if (schema)
+                schemas.set(name, schema);
             return true;
+        },
+        describe(name) {
+            return schemas.get(name);
+        },
+        listSchemas() {
+            const out = [];
+            for (const [name, schema] of schemas) {
+                if (!handlers.has(name))
+                    continue;
+                out.push({ name, schema });
+            }
+            return out;
         },
     };
 }

--- a/dist/src/version.d.ts
+++ b/dist/src/version.d.ts
@@ -1,2 +1,2 @@
-export declare const VERSION = "0.260422.10";
+export declare const VERSION = "0.260423.3";
 //# sourceMappingURL=version.d.ts.map

--- a/dist/src/version.js
+++ b/dist/src/version.js
@@ -1,2 +1,2 @@
-export const VERSION = '0.260422.10';
+export const VERSION = '0.260423.3';
 //# sourceMappingURL=version.js.map

--- a/dist/tests/sdk-rlm-driver-tools.test.d.ts
+++ b/dist/tests/sdk-rlm-driver-tools.test.d.ts
@@ -1,0 +1,14 @@
+/**
+ * rlmx#78 — tool-dispatch driver tests.
+ *
+ * Covers the multi-turn native-function-calling loop added to
+ * rlmDriver when a `tools` config is present. The legacy one-shot
+ * path is covered by `sdk-rlm-driver.test.ts`; this file is purely
+ * the tool-dispatch surface.
+ *
+ * All tests are hermetic — they inject a `toolsLlm` mock in place of
+ * `completeSimple` so no live LLM is called. A separate LIVE smoke
+ * is deferred to the integration suite (gated on GEMINI_API_KEY).
+ */
+export {};
+//# sourceMappingURL=sdk-rlm-driver-tools.test.d.ts.map

--- a/dist/tests/sdk-rlm-driver-tools.test.js
+++ b/dist/tests/sdk-rlm-driver-tools.test.js
@@ -1,0 +1,465 @@
+/**
+ * rlmx#78 — tool-dispatch driver tests.
+ *
+ * Covers the multi-turn native-function-calling loop added to
+ * rlmDriver when a `tools` config is present. The legacy one-shot
+ * path is covered by `sdk-rlm-driver.test.ts`; this file is purely
+ * the tool-dispatch surface.
+ *
+ * All tests are hermetic — they inject a `toolsLlm` mock in place of
+ * `completeSimple` so no live LLM is called. A separate LIVE smoke
+ * is deferred to the integration suite (gated on GEMINI_API_KEY).
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createToolRegistry, rlmDriver, runAgent, } from "../src/sdk/index.js";
+const MODEL = {
+    provider: "google",
+    model: "gemini-2.5-flash",
+};
+function makeAssistant(blocks, stopReason = "stop") {
+    return {
+        role: "assistant",
+        content: blocks,
+        api: "google-generative-ai",
+        provider: "google",
+        model: "gemini-2.5-flash",
+        usage: {
+            input: 10,
+            output: 5,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 15,
+            cost: {
+                input: 0.001,
+                output: 0.002,
+                cacheRead: 0,
+                cacheWrite: 0,
+                total: 0.003,
+            },
+        },
+        stopReason,
+        timestamp: Date.now(),
+    };
+}
+function makeToolCall(id, name, args) {
+    return { type: "toolCall", id, name, arguments: args };
+}
+async function drain(stream) {
+    const events = [];
+    for await (const ev of stream)
+        events.push(ev);
+    return events;
+}
+const SEARCH_SCHEMA = {
+    description: "Search the brain corpus for entries matching a query.",
+    parameters: {
+        type: "object",
+        properties: {
+            query: { type: "string", description: "Search query" },
+        },
+        required: ["query"],
+    },
+};
+const READ_SCHEMA = {
+    description: "Read a specific brain entry by id.",
+    parameters: {
+        type: "object",
+        properties: {
+            id: { type: "string", description: "Entry id" },
+        },
+        required: ["id"],
+    },
+};
+describe("rlmDriver tool-dispatch — step shape (hermetic)", () => {
+    it("no schemas in registry → falls back to legacy one-shot mode", async () => {
+        // Registry with handlers but NO schemas — tool-dispatch path
+        // needs at least one schema to engage; fall back is the safe
+        // default so consumers don't accidentally switch modes.
+        const registry = createToolRegistry();
+        registry.register("unused", async () => "irrelevant");
+        const driver = rlmDriver({
+            model: MODEL,
+            tools: { registry },
+            llm: async () => ({
+                text: "hi there",
+                usage: {
+                    inputTokens: 0,
+                    outputTokens: 0,
+                    cacheReadTokens: 0,
+                    cacheWriteTokens: 0,
+                    totalCost: 0,
+                    llmCalls: 1,
+                },
+            }),
+        });
+        const steps = [];
+        const iter = driver({ sessionId: "s", iteration: 1, history: [{ role: "user", content: "hi" }] }, new AbortController().signal);
+        for await (const step of iter)
+            steps.push(step);
+        assert.equal(steps.length, 2);
+        assert.equal(steps[0]?.kind, "message");
+        assert.equal(steps[1]?.kind, "emit_done");
+    });
+    it("single tool call → yields tool_call step with name, args, id", async () => {
+        const registry = createToolRegistry();
+        registry.register("search_corpus", async () => [], SEARCH_SCHEMA);
+        let llmCalls = 0;
+        const toolsLlm = async () => {
+            llmCalls++;
+            if (llmCalls === 1) {
+                return makeAssistant([makeToolCall("call_1", "search_corpus", { query: "gravity" })], "toolUse");
+            }
+            return makeAssistant([{ type: "text", text: "Final answer: nothing found." }]);
+        };
+        const driver = rlmDriver({
+            model: MODEL,
+            tools: { registry },
+            toolsLlm,
+        });
+        const steps = [];
+        const iter = driver({ sessionId: "s", iteration: 1, history: [{ role: "user", content: "find gravity" }] }, new AbortController().signal);
+        // First step should be the tool_call.
+        let res = await iter.next();
+        assert.ok(!res.done);
+        assert.equal(res.value?.kind, "tool_call");
+        assert.equal(res.value.tool, "search_corpus");
+        assert.deepEqual(res.value.args, { query: "gravity" });
+        assert.equal(res.value.id, "call_1");
+        // Feed the outcome back; next we expect the final message + emit_done.
+        res = await iter.next({
+            tool: "search_corpus",
+            ok: true,
+            result: { hits: [] },
+            durationMs: 3,
+        });
+        assert.ok(!res.done);
+        assert.equal(res.value?.kind, "message");
+        res = await iter.next();
+        assert.ok(!res.done);
+        assert.equal(res.value?.kind, "emit_done");
+        res = await iter.next();
+        assert.ok(res.done);
+        assert.equal(llmCalls, 2);
+    });
+    it("multiple tool calls in one assistant response → yielded sequentially", async () => {
+        const registry = createToolRegistry();
+        registry.register("search_corpus", async () => [], SEARCH_SCHEMA);
+        registry.register("read", async () => "", READ_SCHEMA);
+        let llmCalls = 0;
+        const toolsLlm = async () => {
+            llmCalls++;
+            if (llmCalls === 1) {
+                return makeAssistant([
+                    makeToolCall("call_a", "search_corpus", { query: "foo" }),
+                    makeToolCall("call_b", "read", { id: "entry_1" }),
+                ], "toolUse");
+            }
+            return makeAssistant([{ type: "text", text: "done" }]);
+        };
+        const driver = rlmDriver({
+            model: MODEL,
+            tools: { registry },
+            toolsLlm,
+        });
+        const steps = [];
+        const iter = driver({ sessionId: "s", iteration: 1, history: [{ role: "user", content: "do both" }] }, new AbortController().signal);
+        // 1st: tool_call search_corpus
+        let res = await iter.next();
+        assert.equal(res.value?.kind, "tool_call");
+        assert.equal(res.value.tool, "search_corpus");
+        steps.push(res.value);
+        // 2nd: after outcome, tool_call read
+        res = await iter.next({ tool: "search_corpus", ok: true, result: [], durationMs: 1 });
+        assert.equal(res.value?.kind, "tool_call");
+        assert.equal(res.value.tool, "read");
+        // 3rd: after outcome, message
+        res = await iter.next({ tool: "read", ok: true, result: "body", durationMs: 2 });
+        assert.equal(res.value?.kind, "message");
+        // 4th: emit_done
+        res = await iter.next();
+        assert.equal(res.value?.kind, "emit_done");
+    });
+    it("tool error outcome → driver feeds error text back to LLM, not abort", async () => {
+        const registry = createToolRegistry();
+        registry.register("search_corpus", async () => {
+            throw new Error("index unavailable");
+        }, SEARCH_SCHEMA);
+        const seenTurns = [];
+        let llmCalls = 0;
+        const toolsLlm = async (ctx) => {
+            seenTurns.push({ ...ctx, messages: [...ctx.messages] });
+            llmCalls++;
+            if (llmCalls === 1) {
+                return makeAssistant([makeToolCall("c1", "search_corpus", { query: "x" })], "toolUse");
+            }
+            return makeAssistant([{ type: "text", text: "apologies, the tool failed" }]);
+        };
+        const driver = rlmDriver({
+            model: MODEL,
+            tools: { registry },
+            toolsLlm,
+        });
+        const events = await drain(runAgent({
+            agentId: "t",
+            sessionId: "s-tool-err",
+            input: "search gravity",
+            driver,
+            toolRegistry: registry,
+        }));
+        // Tool failure must NOT abort the run — driver feeds error back,
+        // LLM produces a graceful response, run completes.
+        const close = events.find((e) => e.type === "SessionClose");
+        assert.equal(close?.reason, "complete", "tool error should not abort");
+        // Second LLM call should see a toolResult with isError=true.
+        assert.equal(seenTurns.length, 2);
+        const secondMsgs = seenTurns[1]?.messages ?? [];
+        const errMsg = secondMsgs.find((m) => m.role === "toolResult" && m.isError === true);
+        assert.ok(errMsg, "LLM must see the toolResult with isError");
+    });
+    it("permission-denied outcome → driver surfaces denial to LLM", async () => {
+        const registry = createToolRegistry();
+        let handlerCalled = false;
+        registry.register("search_corpus", async () => {
+            handlerCalled = true;
+            return [];
+        }, SEARCH_SCHEMA);
+        let llmCalls = 0;
+        const toolsLlm = async (ctx) => {
+            llmCalls++;
+            if (llmCalls === 1) {
+                return makeAssistant([makeToolCall("c1", "search_corpus", { query: "blocked" })], "toolUse");
+            }
+            return makeAssistant([{ type: "text", text: "cannot search, understood" }]);
+        };
+        const driver = rlmDriver({
+            model: MODEL,
+            tools: { registry },
+            toolsLlm,
+        });
+        const events = await drain(runAgent({
+            agentId: "t",
+            sessionId: "s-deny",
+            input: "search",
+            driver,
+            toolRegistry: registry,
+            permissionHooks: [
+                async () => ({ decision: "deny", reason: "access policy X" }),
+            ],
+        }));
+        assert.equal(handlerCalled, false, "handler must NOT run on deny");
+        const close = events.find((e) => e.type === "SessionClose");
+        assert.equal(close?.reason, "complete");
+        // The ToolCallAfter event should carry ok:false + result:null for
+        // the denied call.
+        const afters = events.filter((e) => e.type === "ToolCallAfter");
+        assert.equal(afters[0]?.ok, false);
+        assert.equal(afters[0]?.result, null);
+    });
+    it("emit_done tool call short-circuits → payload becomes the emit_done payload", async () => {
+        const registry = createToolRegistry();
+        registry.register("emit_done", async () => null, {
+            description: "Signal completion",
+            parameters: {
+                type: "object",
+                properties: { answer: { type: "string" } },
+                required: ["answer"],
+            },
+        });
+        const toolsLlm = async () => makeAssistant([makeToolCall("c1", "emit_done", { answer: "42" })], "toolUse");
+        const driver = rlmDriver({
+            model: MODEL,
+            tools: { registry },
+            toolsLlm,
+        });
+        const events = await drain(runAgent({
+            agentId: "t",
+            sessionId: "s-emit-done-tool",
+            input: "what is the answer?",
+            driver,
+            toolRegistry: registry,
+        }));
+        const emitDone = events.find((e) => e.type === "EmitDone");
+        assert.ok(emitDone);
+        assert.equal(emitDone?.payload?.answer, "42");
+    });
+    it("maxToolIterations cap → driver yields error when LLM keeps calling tools", async () => {
+        const registry = createToolRegistry();
+        registry.register("search_corpus", async () => [], SEARCH_SCHEMA);
+        const toolsLlm = async () => makeAssistant([makeToolCall("c_loop", "search_corpus", { query: "loop" })], "toolUse");
+        const driver = rlmDriver({
+            model: MODEL,
+            tools: { registry, maxToolIterations: 3 },
+            toolsLlm,
+        });
+        const events = await drain(runAgent({
+            agentId: "t",
+            sessionId: "s-loop-cap",
+            input: "loop forever",
+            driver,
+            toolRegistry: registry,
+        }));
+        const err = events.find((e) => e.type === "Error" &&
+            e.phase === "driver");
+        assert.ok(err);
+        assert.match(err?.error?.message ?? "", /maxToolIterations/);
+    });
+    it("expose allowlist limits tools offered to the LLM", async () => {
+        const registry = createToolRegistry();
+        registry.register("search_corpus", async () => [], SEARCH_SCHEMA);
+        registry.register("read", async () => "", READ_SCHEMA);
+        registry.register("propose_yaml", async () => null, {
+            description: "Stage a yaml draft for review",
+            parameters: {
+                type: "object",
+                properties: { path: { type: "string" } },
+                required: ["path"],
+            },
+        });
+        const seen = [];
+        const toolsLlm = async (ctx) => {
+            seen.push(ctx);
+            return makeAssistant([{ type: "text", text: "ok" }]);
+        };
+        const driver = rlmDriver({
+            model: MODEL,
+            tools: {
+                registry,
+                expose: ["read", "propose_yaml"], // search_corpus is hidden
+            },
+            toolsLlm,
+        });
+        await drain(runAgent({
+            agentId: "t",
+            sessionId: "s-expose",
+            input: "go",
+            driver,
+            toolRegistry: registry,
+        }));
+        const offered = (seen[0]?.tools ?? []).map((t) => t.name);
+        assert.deepEqual(offered, ["read", "propose_yaml"]);
+    });
+    it("interim text between tool calls surfaces as Message events", async () => {
+        const registry = createToolRegistry();
+        registry.register("search_corpus", async () => [], SEARCH_SCHEMA);
+        let call = 0;
+        const toolsLlm = async () => {
+            call++;
+            if (call === 1) {
+                return makeAssistant([
+                    { type: "text", text: "Let me search first." },
+                    makeToolCall("c1", "search_corpus", { query: "x" }),
+                ], "toolUse");
+            }
+            return makeAssistant([{ type: "text", text: "Done searching." }]);
+        };
+        const driver = rlmDriver({
+            model: MODEL,
+            tools: { registry },
+            toolsLlm,
+        });
+        const events = await drain(runAgent({
+            agentId: "t",
+            sessionId: "s-interim",
+            input: "go",
+            driver,
+            toolRegistry: registry,
+        }));
+        const messages = events.filter((e) => e.type === "Message");
+        const contents = messages.map((m) => m.content);
+        assert.ok(contents.includes("Let me search first."));
+        assert.ok(contents.includes("Done searching."));
+    });
+});
+describe("rlmDriver tier-2 integration — brain tools stub end-to-end", () => {
+    it("search → read → propose_yaml → final answer pipeline works", async () => {
+        // This is the "Tier 2 brain-consuming agent" pattern from
+        // brain's runbook/custom-rlmx-agents.md — the flow the issue
+        // calls out as the killer use case. Stubs stand in for the
+        // real brain_tools.py handlers.
+        const registry = createToolRegistry();
+        const searchCalls = [];
+        const readCalls = [];
+        const proposeCalls = [];
+        registry.register("search_corpus", async (args) => {
+            searchCalls.push(args);
+            return { hits: [{ id: "entry_42", score: 0.91 }] };
+        }, SEARCH_SCHEMA);
+        registry.register("read", async (args) => {
+            readCalls.push(args);
+            return {
+                id: "entry_42",
+                title: "diego fernandes",
+                body: "client since 2024-06",
+            };
+        }, READ_SCHEMA);
+        registry.register("propose_yaml", async (args) => {
+            proposeCalls.push(args);
+            return { staged: true, path: "_pending/2026-04-23/diego.md" };
+        }, {
+            description: "Stage a yaml proposal under _pending/",
+            parameters: {
+                type: "object",
+                properties: {
+                    path: { type: "string" },
+                    content: { type: "string" },
+                },
+                required: ["path", "content"],
+            },
+        });
+        let turn = 0;
+        const toolsLlm = async () => {
+            turn++;
+            if (turn === 1) {
+                return makeAssistant([makeToolCall("c1", "search_corpus", { query: "diego" })], "toolUse");
+            }
+            if (turn === 2) {
+                return makeAssistant([makeToolCall("c2", "read", { id: "entry_42" })], "toolUse");
+            }
+            if (turn === 3) {
+                return makeAssistant([
+                    makeToolCall("c3", "propose_yaml", {
+                        path: "_pending/2026-04-23/diego.md",
+                        content: "name: Diego Fernandes",
+                    }),
+                ], "toolUse");
+            }
+            return makeAssistant([
+                {
+                    type: "text",
+                    text: "Staged proposal at _pending/2026-04-23/diego.md",
+                },
+            ]);
+        };
+        const driver = rlmDriver({
+            model: MODEL,
+            tools: { registry },
+            toolsLlm,
+        });
+        const events = await drain(runAgent({
+            agentId: "tier2-test",
+            sessionId: "s-tier2",
+            input: "extract diego's contact entry",
+            driver,
+            toolRegistry: registry,
+        }));
+        // All three tools were actually invoked.
+        assert.deepEqual(searchCalls, [{ query: "diego" }]);
+        assert.deepEqual(readCalls, [{ id: "entry_42" }]);
+        assert.equal(proposeCalls.length, 1);
+        // Run completed cleanly.
+        const close = events.find((e) => e.type === "SessionClose");
+        assert.equal(close?.reason, "complete");
+        // emit_done payload carries the final answer.
+        const emitDone = events.find((e) => e.type === "EmitDone");
+        assert.ok(emitDone);
+        assert.match(emitDone?.payload?.answer ?? "", /_pending\/2026-04-23\/diego\.md/);
+        assert.equal(emitDone?.payload?.toolCalls, 3);
+        // ToolCallBefore/After events bracket each dispatch, in order.
+        const beforeNames = events
+            .filter((e) => e.type === "ToolCallBefore")
+            .map((e) => e.tool);
+        assert.deepEqual(beforeNames, ["search_corpus", "read", "propose_yaml"]);
+    });
+});
+//# sourceMappingURL=sdk-rlm-driver-tools.test.js.map

--- a/src/sdk/agent.ts
+++ b/src/sdk/agent.ts
@@ -74,6 +74,24 @@ import {
 	validateAgainstSchema,
 } from "./validate.js";
 
+/**
+ * Outcome of a tool_call dispatch, fed back to the driver via
+ * `AsyncGenerator.next(outcome)` so multi-turn drivers (rlmDriver
+ * in tool-dispatch mode, rlmx#78) can fold the result into the
+ * next LLM call as conversation history.
+ */
+export interface ToolCallOutcome {
+	readonly tool: string;
+	readonly ok: boolean;
+	readonly result: unknown;
+	readonly error?: { readonly name: string; readonly message: string };
+	readonly durationMs: number;
+	/** True when the permission chain denied the call. `result` is null and
+	 *  `ok` is false in this case; drivers that want to explain the denial
+	 *  to the LLM should surface `error.message` as a tool-result note. */
+	readonly denied?: boolean;
+}
+
 /** One step produced by an `IterationDriver` during a single iteration. */
 export type IterationStep =
 	| {
@@ -85,6 +103,11 @@ export type IterationStep =
 			readonly kind: "tool_call";
 			readonly tool: string;
 			readonly args: unknown;
+			/** Optional LLM-issued id (e.g. Gemini `functionCall.id`,
+			 *  Anthropic `tool_use.id`). Drivers that need to pair
+			 *  outcomes with ToolResultMessage.toolCallId should set
+			 *  this so the outcome comes back correlated. */
+			readonly id?: string;
 	  }
 	| {
 			/**
@@ -116,10 +139,26 @@ export interface IterationRequest {
 	readonly retryHint?: string;
 }
 
+/**
+ * An `IterationDriver` is an async generator that runAgent pumps.
+ *
+ * runAgent uses manual iteration (`iter.next(value)`) so drivers can
+ * receive tool-call outcomes back from runAgent — the generator's
+ * `yield` returns the `ToolCallOutcome` when the previously yielded
+ * step was a `tool_call` and runAgent finished dispatching it. For
+ * any other step kind (message, emit_done, error,
+ * tool_call_observation) the yield returns `undefined`.
+ *
+ * Drivers that don't care about tool outcomes (e.g. the legacy
+ * one-shot rlmDriver path) can just `yield step` and ignore the
+ * return value — behavior is unchanged from the pre-rlmx#78 contract.
+ */
 export type IterationDriver = (
 	req: IterationRequest,
 	signal: AbortSignal,
-) => AsyncIterable<IterationStep>;
+) =>
+	| AsyncIterable<IterationStep>
+	| AsyncGenerator<IterationStep, void, ToolCallOutcome | undefined>;
 
 /** Resolves a tool invocation. Called after a non-deny permission
  *  decision. When omitted, tool calls are recorded but not executed
@@ -315,7 +354,28 @@ async function drive(
 			};
 			let iterOutput = "";
 
-			for await (const step of driver(req, ac.signal)) {
+			// Manual iteration so we can push tool outcomes back into the
+			// driver via `.next(outcome)`. Async generators treat a call
+			// to `.next(value)` as the return value of the current `yield`,
+			// which is how multi-turn drivers (rlmDriver in tool-dispatch
+			// mode) fold tool results back into the next LLM call.
+			const iter = driver(req, ac.signal) as AsyncGenerator<
+				IterationStep,
+				void,
+				ToolCallOutcome | undefined
+			>;
+			let nextInput: ToolCallOutcome | undefined;
+
+			while (true) {
+				if (ac.signal.aborted) break iterationLoop;
+				const { value: step, done: iterDone } = await iter.next(nextInput);
+				nextInput = undefined;
+				if (iterDone) break;
+				if (!step) continue;
+				// Re-check abort AFTER the driver yielded — the driver
+				// itself may have triggered the abort in its yield
+				// prelude. Matches the pre-rlmx#78 `for await` semantics
+				// which checked before processing each step.
 				if (ac.signal.aborted) break iterationLoop;
 
 				switch (step.kind) {
@@ -379,12 +439,27 @@ async function drive(
 								},
 							} as Omit<ErrorEvent, "type" | "timestamp">);
 							em.emit(err);
+							// Surface the denial to the driver so it can
+							// explain the failure back to the LLM instead
+							// of looping forever re-issuing the call.
+							nextInput = {
+								tool: step.tool,
+								ok: false,
+								result: null,
+								error: {
+									name: "PermissionDenied",
+									message: decision.reason,
+								},
+								durationMs: 0,
+								denied: true,
+							};
 							continue;
 						}
 
 						const t0 = Date.now();
 						let result: unknown = null;
 						let ok = true;
+						let toolError: Error | undefined;
 						try {
 							if (toolRegistry || toolResolver) {
 								result = await dispatchTool(
@@ -395,26 +470,37 @@ async function drive(
 							}
 						} catch (e) {
 							ok = false;
-							result = e instanceof Error ? e.message : String(e);
+							toolError = e instanceof Error ? e : new Error(String(e));
+							result = toolError.message;
 							const err: ErrorEvent = makeEvent("Error", {
 								sessionId,
 								phase: "tool",
 								error: {
-									name: e instanceof Error ? e.name : "Error",
-									message: e instanceof Error ? e.message : String(e),
+									name: toolError.name,
+									message: toolError.message,
 								},
 							} as Omit<ErrorEvent, "type" | "timestamp">);
 							em.emit(err);
 						}
+						const durationMs = Date.now() - t0;
 						const after: ToolCallAfterEvent = makeEvent("ToolCallAfter", {
 							sessionId,
 							iteration,
 							tool: step.tool,
 							result,
-							durationMs: Date.now() - t0,
+							durationMs,
 							ok,
 						} as Omit<ToolCallAfterEvent, "type" | "timestamp">);
 						em.emit(after);
+						nextInput = {
+							tool: step.tool,
+							ok,
+							result,
+							error: toolError
+								? { name: toolError.name, message: toolError.message }
+								: undefined,
+							durationMs,
+						};
 						continue;
 					}
 

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -82,12 +82,16 @@ export type {
 	IterationDriver,
 	IterationRequest,
 	IterationStep,
+	ToolCallOutcome,
 	ToolResolver,
 } from "./agent.js";
 
-// ─── rlmDriver (G2c — real LLM bridge) ───────────────────────────
+// ─── rlmDriver (G2c — real LLM bridge + rlmx#78 tool dispatch) ───
 export { formatRlmPrompt, rlmDriver } from "./rlm-driver.js";
-export type { RlmDriverConfig } from "./rlm-driver.js";
+export type {
+	RlmDriverConfig,
+	RlmDriverToolsConfig,
+} from "./rlm-driver.js";
 
 // ─── Agent spec + tool plugin loader (G3a) ───────────────────────
 export {
@@ -101,7 +105,7 @@ export {
 	toolRegistryAsResolver,
 	UnknownToolError,
 } from "./tool-registry.js";
-export type { ToolContext, ToolHandler, ToolRegistry } from "./tool-registry.js";
+export type { ToolContext, ToolHandler, ToolRegistry, ToolSchema } from "./tool-registry.js";
 export {
 	InvalidPluginError,
 	MissingPluginError,

--- a/src/sdk/rlm-driver.ts
+++ b/src/sdk/rlm-driver.ts
@@ -1,37 +1,114 @@
 /**
- * rlm-driver — Wish B Group 2b/c.
+ * rlm-driver — Wish B Group 2b/c + rlmx#78.
  *
- * Adapts the rlmx LLM backend (`llmCompleteSimple` from `src/llm.ts`)
- * to the `IterationDriver` contract defined in `src/sdk/agent.ts`.
- * Lets `runAgent()` drive a real LLM end-to-end so permissions,
- * validate, session, and events tick through with production-shaped
- * responses instead of canned fixtures.
+ * Adapts the rlmx LLM backend to the `IterationDriver` contract
+ * defined in `src/sdk/agent.ts`. Two modes:
+ *
+ *   1. **Legacy one-shot mode** (no `tools` config) — the original
+ *      behavior: one `llmCompleteSimple` call per iteration, whole
+ *      response surfaced as `emit_done.payload.answer`. Preserved
+ *      byte-compatibly so existing consumers (cli cutover, simple
+ *      agents without tools) keep working.
+ *
+ *   2. **Tool-dispatch mode** (rlmx#78, `tools` config present) —
+ *      multi-turn conversation loop with native function-calling:
+ *
+ *        • ToolRegistry schemas → pi-ai `Tool[]` → provider-native
+ *          function declarations (Gemini functionDeclarations,
+ *          Anthropic tools, OpenAI functions — pi-ai handles the
+ *          per-provider shape).
+ *        • Each LLM call is followed by a check for `ToolCall`
+ *          content blocks; any that are present are yielded as
+ *          `tool_call` steps, their outcomes come back via
+ *          `yield`'s return value (runAgent manual-iterates), and
+ *          we append a `toolResult` message to the pi-ai history
+ *          before the next call.
+ *        • Loop terminates when the LLM emits a pure-text
+ *          response (stopReason === "stop") OR an explicit
+ *          `emit_done` tool call OR the max-tool-iterations cap
+ *          is hit.
+ *        • runAgent's permission chain, validate retry pipeline,
+ *          session/checkpoint primitives all continue to fire —
+ *          the driver stays hermetic and the event flow is
+ *          identical to the G2b contract.
  *
  * Design constraints:
  *
  *   • Zero touch to `src/rlm.ts` — the existing CLI entry (`rlmLoop`)
  *     stays byte-for-byte unchanged. This module is additive.
- *   • Shares the same LLM transport (`llmCompleteSimple`) rlm.ts uses,
- *     so any provider / thinking-level / budget work that lands in
+ *   • Legacy path still shares `llmCompleteSimple` with rlm.ts, so
+ *     any provider / thinking-level / budget work that lands in
  *     `llm.ts` automatically benefits this driver.
- *   • Keeps the surface minimal: one LLM call per iteration, full
- *     response surfaced as a `Message` event, terminal `emit_done`
- *     with the response as payload. Parsing `rlmx`-specific Python
- *     tool-call code blocks is deliberately NOT done here — that's a
- *     larger slice that also requires a REPL executor. This driver
- *     proves the wiring; a follow-up can layer tool dispatch on top.
+ *   • Tool-dispatch path calls pi-ai `completeSimple` directly —
+ *     the tool-aware plumbing (Context.tools, ToolResultMessage,
+ *     preserving AssistantMessage across turns) is inherent to
+ *     pi-ai's transport layer, so we bypass the legacy `llm.ts`
+ *     wrapper rather than bolt tool support on there.
+ *   • Python REPL tool-call parsing (rlmx-specific ```tool_call``` code
+ *     blocks) is still NOT done here — that's the rlm.ts CLI's
+ *     concern and a separate slice. This driver does NATIVE
+ *     function-calling only, which is what Tier 2 brain-consuming
+ *     agents need.
  *
- * Consumers compose it via `runAgent({ driver: rlmDriver(cfg) })` —
- * never called directly by user code.
+ * Consumers compose it via `runAgent({ driver: rlmDriver(cfg),
+ * toolRegistry: registry })` — never called directly by user code.
  *
  * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L93 (wave 5
  * dogfood), plus the "prove end-to-end wiring against real LLM"
- * mandate added in the G2b review cycle.
+ * mandate added in the G2b review cycle; rlmx#78 for the native
+ * tool-dispatch loop that unblocks Tier 2 agents.
  */
 
+import {
+	completeSimple as piCompleteSimple,
+	getModel as piGetModel,
+} from "@mariozechner/pi-ai";
+import type {
+	AssistantMessage as PiAssistantMessage,
+	Context as PiContext,
+	KnownProvider,
+	Message as PiMessage,
+	SimpleStreamOptions as PiSimpleStreamOptions,
+	Tool as PiTool,
+	ToolCall as PiToolCall,
+	ToolResultMessage as PiToolResultMessage,
+	UserMessage as PiUserMessage,
+} from "@mariozechner/pi-ai";
 import type { ModelConfig } from "../config.js";
 import { llmCompleteSimple, type LLMResponse } from "../llm.js";
-import type { IterationDriver, IterationRequest } from "./agent.js";
+import type {
+	IterationDriver,
+	IterationRequest,
+	IterationStep,
+	ToolCallOutcome,
+} from "./agent.js";
+import type { ToolRegistry, ToolSchema } from "./tool-registry.js";
+
+/**
+ * Tool-dispatch config for rlmx#78. When present on `RlmDriverConfig`,
+ * the driver enters multi-turn tool-dispatch mode.
+ */
+export interface RlmDriverToolsConfig {
+	/** Source of tool schemas the LLM will be offered. Must have at
+	 *  least one tool with a schema (via `registry.register(name,
+	 *  handler, schema)`) — otherwise the driver falls back to
+	 *  one-shot mode for safety. */
+	readonly registry: ToolRegistry;
+	/**
+	 * Hard cap on LLM calls per iteration (defense against infinite
+	 * tool-calling loops). When exceeded, the driver yields an
+	 * `error` step with the partial answer. Default: 16.
+	 */
+	readonly maxToolIterations?: number;
+	/**
+	 * Optional list of tool names to expose to the LLM. When
+	 * omitted, every registry tool with a schema is exposed. Useful
+	 * when the agent.yaml whitelist is stricter than the registry
+	 * (e.g. RTK pre-registered tools you don't want this agent to
+	 * see). Order is preserved in the tools[] array.
+	 */
+	readonly expose?: readonly string[];
+}
 
 export interface RlmDriverConfig {
 	/** Model config — same shape rlm.ts uses. */
@@ -39,9 +116,13 @@ export interface RlmDriverConfig {
 	/** Optional SYSTEM.md contents; prepended to each turn's prompt. */
 	readonly system?: string;
 	/**
-	 * Injectable LLM completion fn. Defaults to the real
-	 * `llmCompleteSimple` so production just calls Gemini. Tests pass a
-	 * mock to validate the driver's event sequence without a live model.
+	 * Injectable LLM completion fn for the legacy (no-tools) path.
+	 * Defaults to the real `llmCompleteSimple` so production just
+	 * calls Gemini. Tests pass a mock to validate the driver's event
+	 * sequence without a live model. Ignored when `tools` is set —
+	 * the tool-dispatch path needs pi-ai's native `completeSimple`
+	 * for tool-aware transport, and exposes a separate `toolsLlm`
+	 * injection point for tests.
 	 */
 	readonly llm?: (
 		prompt: string,
@@ -55,10 +136,28 @@ export interface RlmDriverConfig {
 	 * labelled block.
 	 */
 	readonly retryHintFormatter?: (hint: string) => string;
+	/**
+	 * Tool-dispatch config (rlmx#78). When set, switches the driver
+	 * into multi-turn native-function-calling mode.
+	 */
+	readonly tools?: RlmDriverToolsConfig;
+	/**
+	 * Injectable pi-ai completion fn for the tool-dispatch path.
+	 * Defaults to the real `completeSimple` so production just calls
+	 * Gemini / Anthropic / OpenAI with native function-calling. Tests
+	 * pass a mock to validate the tool loop without a live model.
+	 */
+	readonly toolsLlm?: (
+		context: PiContext,
+		modelConfig: ModelConfig,
+		signal?: AbortSignal,
+	) => Promise<PiAssistantMessage>;
 }
 
 const DEFAULT_RETRY_FORMATTER = (hint: string): string =>
 	`# Retry hint from the validator\n\n${hint}\n\n`;
+
+const DEFAULT_MAX_TOOL_ITERATIONS = 16;
 
 /**
  * Render the iteration's prompt. Keeps it intentionally simple — the
@@ -96,16 +195,88 @@ export function formatRlmPrompt(
 }
 
 /**
- * Build an `IterationDriver` that drives one LLM call per iteration.
- * The returned async generator yields a single `message` step with the
- * full response text followed by an `emit_done` step carrying the
- * response as a structured payload: `{ answer: string; usage: UsageStats }`.
- *
- * When the LLM fails (throws, or returns an empty string), the driver
- * yields an `error` step so `runAgent` can surface it as `Error{phase:"driver"}`
- * and close the session with `reason: "error"`.
+ * Resolve a pi-ai Model using the same fallback strategy as llm.ts
+ * (try exact id, then strip date suffix). Kept in-sync with `llm.ts`
+ * `resolveModel` — when that helper goes public we'll import it.
+ */
+function resolvePiModel(provider: string, modelId: string) {
+	let model = piGetModel(provider as KnownProvider, modelId as never);
+	if (!model) {
+		const stripped = modelId.replace(/-\d{8}$/, "");
+		if (stripped !== modelId) {
+			model = piGetModel(provider as KnownProvider, stripped as never);
+		}
+	}
+	if (!model) {
+		throw new Error(
+			`rlmDriver: unknown model "${modelId}" for provider "${provider}".`,
+		);
+	}
+	return model;
+}
+
+/**
+ * Turn a ToolRegistry + optional allowlist into pi-ai `Tool[]`. Tools
+ * without schemas are skipped (can't be called by the LLM).
+ */
+function buildPiTools(cfg: RlmDriverToolsConfig): PiTool[] {
+	const allowed = cfg.expose ? new Set(cfg.expose) : null;
+	const out: PiTool[] = [];
+	for (const { name, schema } of cfg.registry.listSchemas()) {
+		if (allowed && !allowed.has(name)) continue;
+		out.push(toPiTool(name, schema));
+	}
+	if (allowed) {
+		// Preserve declared order from `expose` when it's set.
+		out.sort((a, b) => {
+			const ia = cfg.expose?.indexOf(a.name) ?? 0;
+			const ib = cfg.expose?.indexOf(b.name) ?? 0;
+			return ia - ib;
+		});
+	}
+	return out;
+}
+
+function toPiTool(name: string, schema: ToolSchema): PiTool {
+	// pi-ai's `parameters` field expects a TSchema (typebox), but at
+	// runtime it just needs a JSON-Schema-shaped object. Cast at the
+	// boundary — the schema travels opaquely through pi-ai's
+	// per-provider converters (e.g. convertTools in google-shared.ts
+	// accepts `parametersJsonSchema`).
+	const parameters = (schema.parameters ?? {
+		type: "object",
+		properties: {},
+	}) as unknown as PiTool["parameters"];
+	return {
+		name,
+		description: schema.description ?? "",
+		parameters,
+	};
+}
+
+/**
+ * Build an `IterationDriver` that drives the LLM. Legacy one-shot
+ * mode when `tools` is absent; multi-turn tool-dispatch mode (rlmx#78)
+ * when `tools` is present and the registry has at least one schema.
  */
 export function rlmDriver(config: RlmDriverConfig): IterationDriver {
+	// Pick the branch at driver-construction time so runtime doesn't
+	// re-decide per iteration. The returned generator is hermetic:
+	// both branches satisfy `AsyncGenerator<IterationStep, void,
+	// ToolCallOutcome | undefined>`.
+	if (config.tools && config.tools.registry.listSchemas().length > 0) {
+		return buildToolDispatchDriver(config, config.tools);
+	}
+	return buildLegacyDriver(config);
+}
+
+/**
+ * Legacy one-shot driver — preserved byte-compatibly from the pre-rlmx#78
+ * rlmDriver so existing tests + consumers keep passing. Yields a single
+ * `message` step with the full response text followed by an `emit_done`
+ * step carrying `{answer, usage, iteration}`.
+ */
+function buildLegacyDriver(config: RlmDriverConfig): IterationDriver {
 	const llm = config.llm ?? llmCompleteSimple;
 	return async function* (req, signal) {
 		const prompt = formatRlmPrompt(config, req);
@@ -139,4 +310,311 @@ export function rlmDriver(config: RlmDriverConfig): IterationDriver {
 			},
 		};
 	};
+}
+
+/**
+ * Tool-dispatch driver (rlmx#78). Multi-turn loop that:
+ *   1. seeds the pi-ai Context with systemPrompt + user input
+ *      (+ any retryHint),
+ *   2. calls pi-ai completeSimple with tools=<registry schemas>,
+ *   3. inspects the response for ToolCall blocks, yields a
+ *      `tool_call` step per block, awaits the outcome from runAgent
+ *      via `yield`'s return value,
+ *   4. appends ToolResultMessage(s) + the AssistantMessage to the
+ *      conversation history,
+ *   5. repeats until the model emits a pure-text response
+ *      (stopReason === "stop") or the max-tool-iterations cap trips.
+ *
+ * Final text answer → `message` + `emit_done({answer, usage,
+ * iteration, toolCalls})`. When the LLM explicitly invokes an
+ * `emit_done` tool (if registered), its args become the payload.
+ */
+function buildToolDispatchDriver(
+	config: RlmDriverConfig,
+	toolsCfg: RlmDriverToolsConfig,
+): IterationDriver {
+	const maxToolIterations =
+		toolsCfg.maxToolIterations ?? DEFAULT_MAX_TOOL_ITERATIONS;
+	const tools = buildPiTools(toolsCfg);
+	const llm =
+		config.toolsLlm ??
+		(async (ctx, modelCfg, signal) => {
+			const model = resolvePiModel(modelCfg.provider, modelCfg.model);
+			const opts: PiSimpleStreamOptions = { signal };
+			return await piCompleteSimple(model, ctx, opts);
+		});
+
+	return async function* (
+		req: IterationRequest,
+		signal: AbortSignal,
+	): AsyncGenerator<IterationStep, void, ToolCallOutcome | undefined> {
+		// Seed the conversation history from runAgent's `req.history`
+		// (user input + any prior assistant turns runAgent already
+		// validated) + the retry hint (if present).
+		const piMessages: PiMessage[] = [];
+		for (const turn of req.history) {
+			if (turn.role === "user" || turn.role === "system") {
+				piMessages.push({
+					role: "user",
+					content: turn.content,
+					timestamp: Date.now(),
+				} satisfies PiUserMessage);
+			} else {
+				// Assistant turns from history are text-only (runAgent
+				// doesn't reconstruct ToolCall blocks across iterations).
+				// Replay them as a minimal AssistantMessage so pi-ai's
+				// per-provider transforms treat them as valid turns.
+				piMessages.push({
+					role: "assistant",
+					content: [{ type: "text", text: turn.content }],
+					api: "anthropic-messages",
+					provider: config.model.provider,
+					model: config.model.model,
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: {
+							input: 0,
+							output: 0,
+							cacheRead: 0,
+							cacheWrite: 0,
+							total: 0,
+						},
+					},
+					stopReason: "stop",
+					timestamp: Date.now(),
+				} satisfies PiAssistantMessage);
+			}
+		}
+		const systemPrompt = buildSystemPrompt(config, req);
+
+		let aggregatedText = "";
+		let toolCallsDispatched = 0;
+		let lastUsage: {
+			input: number;
+			output: number;
+			cacheRead: number;
+			cacheWrite: number;
+			total: number;
+		} = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 };
+
+		for (let loopIter = 0; loopIter < maxToolIterations; loopIter++) {
+			if (signal.aborted) return;
+
+			const ctx: PiContext = {
+				systemPrompt,
+				messages: piMessages,
+				tools,
+			};
+
+			let assistant: PiAssistantMessage;
+			try {
+				assistant = await llm(ctx, config.model, signal);
+			} catch (err) {
+				yield {
+					kind: "error",
+					error: err instanceof Error ? err : new Error(String(err)),
+				};
+				return;
+			}
+
+			// Accumulate usage across tool loop iterations so the final
+			// emit_done payload reflects the full turn, not just the
+			// last LLM call.
+			if (assistant.usage) {
+				lastUsage = {
+					input: lastUsage.input + (assistant.usage.input ?? 0),
+					output: lastUsage.output + (assistant.usage.output ?? 0),
+					cacheRead:
+						lastUsage.cacheRead + (assistant.usage.cacheRead ?? 0),
+					cacheWrite:
+						lastUsage.cacheWrite + (assistant.usage.cacheWrite ?? 0),
+					total:
+						lastUsage.total +
+						(assistant.usage.cost?.total ?? 0),
+				};
+			}
+
+			// Append the assistant turn to history BEFORE yielding tool
+			// results — pi-ai's next call expects the toolCall blocks
+			// to reference the prior AssistantMessage, not floating
+			// ToolResultMessages.
+			piMessages.push(assistant);
+
+			const textBlocks: string[] = [];
+			const toolCalls: PiToolCall[] = [];
+			for (const block of assistant.content ?? []) {
+				if (block.type === "text") {
+					textBlocks.push(block.text);
+				} else if (block.type === "toolCall") {
+					toolCalls.push(block);
+				}
+				// thinking/thoughtSignature blocks are passed through via
+				// piMessages (they live on the AssistantMessage we
+				// already pushed) — the driver doesn't need to surface
+				// them as runAgent events in this PR.
+			}
+
+			const text = textBlocks.join("").trim();
+			if (text.length > 0) {
+				// Surface interim assistant text as a Message event so
+				// observers (logs, UI) see reasoning between tool calls.
+				yield { kind: "message", role: "assistant", content: text };
+				aggregatedText = text;
+			}
+
+			if (toolCalls.length === 0) {
+				// Pure text response → terminal. stopReason should be
+				// "stop" here; "length" / "error" get surfaced as
+				// errors.
+				if (assistant.stopReason === "error" || assistant.stopReason === "aborted") {
+					yield {
+						kind: "error",
+						error: new Error(
+							`rlmDriver: LLM stopped with reason "${assistant.stopReason}": ${assistant.errorMessage ?? "<no message>"}`,
+						),
+					};
+					return;
+				}
+				if (text.length === 0) {
+					yield {
+						kind: "error",
+						error: new Error(
+							"rlmDriver: LLM returned empty response (no text, no tool calls)",
+						),
+					};
+					return;
+				}
+				yield {
+					kind: "emit_done",
+					payload: {
+						answer: aggregatedText,
+						usage: lastUsage,
+						iteration: req.iteration,
+						toolCalls: toolCallsDispatched,
+					},
+				};
+				return;
+			}
+
+			// Dispatch each tool call sequentially. Sequential dispatch
+			// is safer than parallel (permission hooks may mutate
+			// session state, validate cap assumes ordered replay) and
+			// matches the Gemini / Anthropic reference flow.
+			const results: PiToolResultMessage[] = [];
+			for (const tc of toolCalls) {
+				if (signal.aborted) return;
+
+				// Special-case an `emit_done` tool call: when an agent
+				// wants to stop with structured output, it calls
+				// emit_done(payload) rather than returning free text.
+				// We honor this directly — no need to re-loop the
+				// LLM.
+				if (tc.name === "emit_done") {
+					yield {
+						kind: "emit_done",
+						payload: tc.arguments,
+					};
+					return;
+				}
+
+				const outcome: ToolCallOutcome | undefined = yield {
+					kind: "tool_call",
+					tool: tc.name,
+					args: tc.arguments,
+					id: tc.id,
+				};
+				toolCallsDispatched++;
+
+				// When runAgent dispatched the call, it returns an
+				// outcome via `.next(outcome)` — the return value of
+				// the `yield`. When runAgent was invoked without a
+				// registry/resolver (unit tests that only check the
+				// step sequence), outcome is undefined; substitute a
+				// benign "nothing happened" placeholder so the driver
+				// can continue gracefully.
+				const safeOutcome: ToolCallOutcome = outcome ?? {
+					tool: tc.name,
+					ok: true,
+					result: null,
+					durationMs: 0,
+				};
+
+				results.push(buildToolResult(tc, safeOutcome));
+			}
+
+			// Feed every tool result back in one batch so the next LLM
+			// call sees all outcomes at once. pi-ai / Gemini / Anthropic
+			// all accept interleaved toolResult messages before the
+			// next assistant turn.
+			piMessages.push(...results);
+		}
+
+		// Fell off the loop → exceeded max-tool-iterations cap. Surface
+		// the last accumulated text as an emit_done so consumers don't
+		// lose partial progress, but annotate via error so budget /
+		// alerting plumbing fires.
+		yield {
+			kind: "error",
+			error: new Error(
+				`rlmDriver: exceeded maxToolIterations=${maxToolIterations} without a terminal response`,
+			),
+		};
+	};
+}
+
+/**
+ * Build the systemPrompt for tool-dispatch mode. Combines the
+ * caller-provided `config.system` with any runAgent-supplied retry
+ * hint so the LLM sees both.
+ */
+function buildSystemPrompt(
+	config: RlmDriverConfig,
+	req: IterationRequest,
+): string | undefined {
+	const parts: string[] = [];
+	if (config.system) parts.push(config.system.trim());
+	if (req.retryHint && req.retryHint.length > 0) {
+		const formatter = config.retryHintFormatter ?? DEFAULT_RETRY_FORMATTER;
+		parts.push(formatter(req.retryHint).trim());
+	}
+	if (parts.length === 0) return undefined;
+	return parts.join("\n\n");
+}
+
+/**
+ * Build a pi-ai ToolResultMessage from a ToolCallOutcome + the
+ * original ToolCall. Encodes success results as JSON text so the
+ * LLM sees structured data; errors come through as text with an
+ * "Error:" prefix and `isError: true` so providers that support
+ * tool-error markers (Anthropic) can flag them.
+ */
+function buildToolResult(
+	tc: PiToolCall,
+	outcome: ToolCallOutcome,
+): PiToolResultMessage {
+	const resultText = outcome.ok
+		? formatResultText(outcome.result)
+		: `Error: ${outcome.error?.message ?? String(outcome.result)}`;
+	return {
+		role: "toolResult",
+		toolCallId: tc.id,
+		toolName: tc.name,
+		content: [{ type: "text", text: resultText }],
+		isError: !outcome.ok,
+		timestamp: Date.now(),
+	};
+}
+
+function formatResultText(result: unknown): string {
+	if (typeof result === "string") return result;
+	if (result === null || result === undefined) return "";
+	try {
+		return JSON.stringify(result);
+	} catch {
+		return String(result);
+	}
 }

--- a/src/sdk/tool-registry.ts
+++ b/src/sdk/tool-registry.ts
@@ -1,5 +1,5 @@
 /**
- * Tool registry — Wish B Group 3a.
+ * Tool registry — Wish B Group 3a + rlmx#78.
  *
  * Maps tool names declared in `agent.yaml` (`tools: [...]`) to
  * in-process handler functions the SDK can dispatch to. Both
@@ -7,11 +7,20 @@
  * handlers (TS plugins from `<agent-dir>/tools/<name>.ts`) land in
  * the same registry.
  *
- * The registry is deliberately boring: `register`, `get`, `list`,
- * `has`. Anything richer — permission overlays, timeouts, retries —
- * belongs in the runAgent dispatch path, not here.
+ * Each handler may carry an optional `ToolSchema` (rlmx#78) — the
+ * description + JSON-Schema parameters the rlmDriver feeds into the
+ * LLM's native function-calling channel. Handlers without schemas are
+ * still dispatchable (via explicit `tool_call` steps emitted by a
+ * driver that composes the args another way) but will NOT be exposed
+ * to the LLM as callable functions.
  *
- * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L24, L164-168.
+ * The registry is deliberately boring: `register`, `get`, `list`,
+ * `has`, `describe`, `listSchemas`. Anything richer — permission
+ * overlays, timeouts, retries — belongs in the runAgent dispatch path,
+ * not here.
+ *
+ * Spec: `.genie/wishes/rlmx-sdk-upgrade/WISH.md` L24, L164-168;
+ * rlmx#78 (tool dispatch in rlmDriver).
  */
 
 import type { ToolResolver } from "./agent.js";
@@ -28,13 +37,38 @@ export type ToolHandler = (
 	ctx: ToolContext,
 ) => Promise<unknown>;
 
+/**
+ * Optional metadata describing a tool's invocation contract. When
+ * present, the rlmDriver forwards this to the LLM as a native
+ * function-calling tool. When absent, the tool is only dispatchable
+ * via out-of-band mechanisms (e.g. a custom driver that emits
+ * `tool_call` steps with args it sourced itself).
+ *
+ * `parameters` is a plain JSON Schema object — any valid draft-07 /
+ * 2020-12 shape works. pi-ai normalizes this for each provider
+ * (Gemini functionDeclarations, Anthropic input_schema, etc.) so the
+ * same object ships to every backend.
+ */
+export interface ToolSchema {
+	readonly description?: string;
+	readonly parameters?: Record<string, unknown>;
+}
+
 export interface ToolRegistry {
-	register(name: string, handler: ToolHandler): void;
+	register(name: string, handler: ToolHandler, schema?: ToolSchema): void;
 	get(name: string): ToolHandler | undefined;
 	has(name: string): boolean;
 	list(): readonly string[];
-	/** Replace the handler for a name if it exists; no-op otherwise. */
-	override(name: string, handler: ToolHandler): boolean;
+	/** Replace the handler for a name if it exists; no-op otherwise.
+	 *  When `schema` is supplied it replaces the existing one. */
+	override(name: string, handler: ToolHandler, schema?: ToolSchema): boolean;
+	/** Metadata describing how the LLM should call this tool. `undefined`
+	 *  when the caller registered a handler without a schema. */
+	describe(name: string): ToolSchema | undefined;
+	/** Snapshot of every `{name, schema}` with a schema attached — the
+	 *  list of tools eligible for native function-calling. Tools
+	 *  without schemas are omitted. */
+	listSchemas(): readonly { readonly name: string; readonly schema: ToolSchema }[];
 }
 
 export class UnknownToolError extends Error {
@@ -49,12 +83,14 @@ export class UnknownToolError extends Error {
 /** Create a fresh in-memory tool registry. Simple Map under the hood. */
 export function createToolRegistry(): ToolRegistry {
 	const handlers = new Map<string, ToolHandler>();
+	const schemas = new Map<string, ToolSchema>();
 	return {
-		register(name, handler) {
+		register(name, handler, schema) {
 			if (name.length === 0) {
 				throw new TypeError("tool registry: name must be non-empty");
 			}
 			handlers.set(name, handler);
+			if (schema) schemas.set(name, schema);
 		},
 		get(name) {
 			return handlers.get(name);
@@ -65,10 +101,22 @@ export function createToolRegistry(): ToolRegistry {
 		list() {
 			return [...handlers.keys()];
 		},
-		override(name, handler) {
+		override(name, handler, schema) {
 			if (!handlers.has(name)) return false;
 			handlers.set(name, handler);
+			if (schema) schemas.set(name, schema);
 			return true;
+		},
+		describe(name) {
+			return schemas.get(name);
+		},
+		listSchemas() {
+			const out: { name: string; schema: ToolSchema }[] = [];
+			for (const [name, schema] of schemas) {
+				if (!handlers.has(name)) continue;
+				out.push({ name, schema });
+			}
+			return out;
 		},
 	};
 }

--- a/tests/sdk-rlm-driver-tools.test.ts
+++ b/tests/sdk-rlm-driver-tools.test.ts
@@ -1,0 +1,639 @@
+/**
+ * rlmx#78 — tool-dispatch driver tests.
+ *
+ * Covers the multi-turn native-function-calling loop added to
+ * rlmDriver when a `tools` config is present. The legacy one-shot
+ * path is covered by `sdk-rlm-driver.test.ts`; this file is purely
+ * the tool-dispatch surface.
+ *
+ * All tests are hermetic — they inject a `toolsLlm` mock in place of
+ * `completeSimple` so no live LLM is called. A separate LIVE smoke
+ * is deferred to the integration suite (gated on GEMINI_API_KEY).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type {
+	AssistantMessage as PiAssistantMessage,
+	Context as PiContext,
+	ToolCall as PiToolCall,
+} from "@mariozechner/pi-ai";
+import type { ModelConfig } from "../src/config.js";
+import {
+	type AgentEvent,
+	createToolRegistry,
+	type IterationStep,
+	rlmDriver,
+	runAgent,
+	type ToolCallOutcome,
+	type ToolSchema,
+} from "../src/sdk/index.js";
+
+const MODEL: ModelConfig = {
+	provider: "google",
+	model: "gemini-2.5-flash",
+};
+
+function makeAssistant(
+	blocks: PiAssistantMessage["content"],
+	stopReason: PiAssistantMessage["stopReason"] = "stop",
+): PiAssistantMessage {
+	return {
+		role: "assistant",
+		content: blocks,
+		api: "google-generative-ai",
+		provider: "google",
+		model: "gemini-2.5-flash",
+		usage: {
+			input: 10,
+			output: 5,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 15,
+			cost: {
+				input: 0.001,
+				output: 0.002,
+				cacheRead: 0,
+				cacheWrite: 0,
+				total: 0.003,
+			},
+		},
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function makeToolCall(
+	id: string,
+	name: string,
+	args: Record<string, unknown>,
+): PiToolCall {
+	return { type: "toolCall", id, name, arguments: args };
+}
+
+async function drain(
+	stream: AsyncIterable<AgentEvent>,
+): Promise<AgentEvent[]> {
+	const events: AgentEvent[] = [];
+	for await (const ev of stream) events.push(ev);
+	return events;
+}
+
+const SEARCH_SCHEMA: ToolSchema = {
+	description: "Search the brain corpus for entries matching a query.",
+	parameters: {
+		type: "object",
+		properties: {
+			query: { type: "string", description: "Search query" },
+		},
+		required: ["query"],
+	},
+};
+
+const READ_SCHEMA: ToolSchema = {
+	description: "Read a specific brain entry by id.",
+	parameters: {
+		type: "object",
+		properties: {
+			id: { type: "string", description: "Entry id" },
+		},
+		required: ["id"],
+	},
+};
+
+describe("rlmDriver tool-dispatch — step shape (hermetic)", () => {
+	it("no schemas in registry → falls back to legacy one-shot mode", async () => {
+		// Registry with handlers but NO schemas — tool-dispatch path
+		// needs at least one schema to engage; fall back is the safe
+		// default so consumers don't accidentally switch modes.
+		const registry = createToolRegistry();
+		registry.register("unused", async () => "irrelevant");
+
+		const driver = rlmDriver({
+			model: MODEL,
+			tools: { registry },
+			llm: async () => ({
+				text: "hi there",
+				usage: {
+					inputTokens: 0,
+					outputTokens: 0,
+					cacheReadTokens: 0,
+					cacheWriteTokens: 0,
+					totalCost: 0,
+					llmCalls: 1,
+				},
+			}),
+		});
+
+		const steps: IterationStep[] = [];
+		const iter = driver(
+			{ sessionId: "s", iteration: 1, history: [{ role: "user", content: "hi" }] },
+			new AbortController().signal,
+		) as AsyncIterable<IterationStep>;
+		for await (const step of iter) steps.push(step);
+		assert.equal(steps.length, 2);
+		assert.equal(steps[0]?.kind, "message");
+		assert.equal(steps[1]?.kind, "emit_done");
+	});
+
+	it("single tool call → yields tool_call step with name, args, id", async () => {
+		const registry = createToolRegistry();
+		registry.register("search_corpus", async () => [], SEARCH_SCHEMA);
+
+		let llmCalls = 0;
+		const toolsLlm = async (): Promise<PiAssistantMessage> => {
+			llmCalls++;
+			if (llmCalls === 1) {
+				return makeAssistant(
+					[makeToolCall("call_1", "search_corpus", { query: "gravity" })],
+					"toolUse",
+				);
+			}
+			return makeAssistant([{ type: "text", text: "Final answer: nothing found." }]);
+		};
+
+		const driver = rlmDriver({
+			model: MODEL,
+			tools: { registry },
+			toolsLlm,
+		});
+
+		const steps: IterationStep[] = [];
+		const iter = driver(
+			{ sessionId: "s", iteration: 1, history: [{ role: "user", content: "find gravity" }] },
+			new AbortController().signal,
+		) as AsyncGenerator<IterationStep, void, ToolCallOutcome | undefined>;
+
+		// First step should be the tool_call.
+		let res = await iter.next();
+		assert.ok(!res.done);
+		assert.equal(res.value?.kind, "tool_call");
+		assert.equal((res.value as { tool: string }).tool, "search_corpus");
+		assert.deepEqual((res.value as { args: unknown }).args, { query: "gravity" });
+		assert.equal((res.value as { id?: string }).id, "call_1");
+
+		// Feed the outcome back; next we expect the final message + emit_done.
+		res = await iter.next({
+			tool: "search_corpus",
+			ok: true,
+			result: { hits: [] },
+			durationMs: 3,
+		});
+		assert.ok(!res.done);
+		assert.equal(res.value?.kind, "message");
+		res = await iter.next();
+		assert.ok(!res.done);
+		assert.equal(res.value?.kind, "emit_done");
+		res = await iter.next();
+		assert.ok(res.done);
+
+		assert.equal(llmCalls, 2);
+	});
+
+	it("multiple tool calls in one assistant response → yielded sequentially", async () => {
+		const registry = createToolRegistry();
+		registry.register("search_corpus", async () => [], SEARCH_SCHEMA);
+		registry.register("read", async () => "", READ_SCHEMA);
+
+		let llmCalls = 0;
+		const toolsLlm = async (): Promise<PiAssistantMessage> => {
+			llmCalls++;
+			if (llmCalls === 1) {
+				return makeAssistant(
+					[
+						makeToolCall("call_a", "search_corpus", { query: "foo" }),
+						makeToolCall("call_b", "read", { id: "entry_1" }),
+					],
+					"toolUse",
+				);
+			}
+			return makeAssistant([{ type: "text", text: "done" }]);
+		};
+
+		const driver = rlmDriver({
+			model: MODEL,
+			tools: { registry },
+			toolsLlm,
+		});
+
+		const steps: IterationStep[] = [];
+		const iter = driver(
+			{ sessionId: "s", iteration: 1, history: [{ role: "user", content: "do both" }] },
+			new AbortController().signal,
+		) as AsyncGenerator<IterationStep, void, ToolCallOutcome | undefined>;
+
+		// 1st: tool_call search_corpus
+		let res = await iter.next();
+		assert.equal(res.value?.kind, "tool_call");
+		assert.equal((res.value as { tool: string }).tool, "search_corpus");
+		steps.push(res.value as IterationStep);
+
+		// 2nd: after outcome, tool_call read
+		res = await iter.next({ tool: "search_corpus", ok: true, result: [], durationMs: 1 });
+		assert.equal(res.value?.kind, "tool_call");
+		assert.equal((res.value as { tool: string }).tool, "read");
+
+		// 3rd: after outcome, message
+		res = await iter.next({ tool: "read", ok: true, result: "body", durationMs: 2 });
+		assert.equal(res.value?.kind, "message");
+		// 4th: emit_done
+		res = await iter.next();
+		assert.equal(res.value?.kind, "emit_done");
+	});
+
+	it("tool error outcome → driver feeds error text back to LLM, not abort", async () => {
+		const registry = createToolRegistry();
+		registry.register("search_corpus", async () => {
+			throw new Error("index unavailable");
+		}, SEARCH_SCHEMA);
+
+		const seenTurns: PiContext[] = [];
+		let llmCalls = 0;
+		const toolsLlm = async (ctx: PiContext): Promise<PiAssistantMessage> => {
+			seenTurns.push({ ...ctx, messages: [...ctx.messages] });
+			llmCalls++;
+			if (llmCalls === 1) {
+				return makeAssistant(
+					[makeToolCall("c1", "search_corpus", { query: "x" })],
+					"toolUse",
+				);
+			}
+			return makeAssistant([{ type: "text", text: "apologies, the tool failed" }]);
+		};
+
+		const driver = rlmDriver({
+			model: MODEL,
+			tools: { registry },
+			toolsLlm,
+		});
+
+		const events = await drain(
+			runAgent({
+				agentId: "t",
+				sessionId: "s-tool-err",
+				input: "search gravity",
+				driver,
+				toolRegistry: registry,
+			}),
+		);
+
+		// Tool failure must NOT abort the run — driver feeds error back,
+		// LLM produces a graceful response, run completes.
+		const close = events.find((e) => e.type === "SessionClose") as
+			| { reason: string }
+			| undefined;
+		assert.equal(close?.reason, "complete", "tool error should not abort");
+
+		// Second LLM call should see a toolResult with isError=true.
+		assert.equal(seenTurns.length, 2);
+		const secondMsgs = seenTurns[1]?.messages ?? [];
+		const errMsg = secondMsgs.find(
+			(m) => m.role === "toolResult" && m.isError === true,
+		);
+		assert.ok(errMsg, "LLM must see the toolResult with isError");
+	});
+
+	it("permission-denied outcome → driver surfaces denial to LLM", async () => {
+		const registry = createToolRegistry();
+		let handlerCalled = false;
+		registry.register("search_corpus", async () => {
+			handlerCalled = true;
+			return [];
+		}, SEARCH_SCHEMA);
+
+		let llmCalls = 0;
+		const toolsLlm = async (ctx: PiContext): Promise<PiAssistantMessage> => {
+			llmCalls++;
+			if (llmCalls === 1) {
+				return makeAssistant(
+					[makeToolCall("c1", "search_corpus", { query: "blocked" })],
+					"toolUse",
+				);
+			}
+			return makeAssistant([{ type: "text", text: "cannot search, understood" }]);
+		};
+
+		const driver = rlmDriver({
+			model: MODEL,
+			tools: { registry },
+			toolsLlm,
+		});
+
+		const events = await drain(
+			runAgent({
+				agentId: "t",
+				sessionId: "s-deny",
+				input: "search",
+				driver,
+				toolRegistry: registry,
+				permissionHooks: [
+					async () => ({ decision: "deny", reason: "access policy X" }),
+				],
+			}),
+		);
+
+		assert.equal(handlerCalled, false, "handler must NOT run on deny");
+		const close = events.find((e) => e.type === "SessionClose") as
+			| { reason: string }
+			| undefined;
+		assert.equal(close?.reason, "complete");
+		// The ToolCallAfter event should carry ok:false + result:null for
+		// the denied call.
+		const afters = events.filter((e) => e.type === "ToolCallAfter") as Array<{
+			ok: boolean;
+			result: unknown;
+		}>;
+		assert.equal(afters[0]?.ok, false);
+		assert.equal(afters[0]?.result, null);
+	});
+
+	it("emit_done tool call short-circuits → payload becomes the emit_done payload", async () => {
+		const registry = createToolRegistry();
+		registry.register("emit_done", async () => null, {
+			description: "Signal completion",
+			parameters: {
+				type: "object",
+				properties: { answer: { type: "string" } },
+				required: ["answer"],
+			},
+		});
+
+		const toolsLlm = async (): Promise<PiAssistantMessage> =>
+			makeAssistant(
+				[makeToolCall("c1", "emit_done", { answer: "42" })],
+				"toolUse",
+			);
+
+		const driver = rlmDriver({
+			model: MODEL,
+			tools: { registry },
+			toolsLlm,
+		});
+
+		const events = await drain(
+			runAgent({
+				agentId: "t",
+				sessionId: "s-emit-done-tool",
+				input: "what is the answer?",
+				driver,
+				toolRegistry: registry,
+			}),
+		);
+
+		const emitDone = events.find((e) => e.type === "EmitDone") as
+			| { payload: { answer: string } }
+			| undefined;
+		assert.ok(emitDone);
+		assert.equal(emitDone?.payload?.answer, "42");
+	});
+
+	it("maxToolIterations cap → driver yields error when LLM keeps calling tools", async () => {
+		const registry = createToolRegistry();
+		registry.register("search_corpus", async () => [], SEARCH_SCHEMA);
+
+		const toolsLlm = async (): Promise<PiAssistantMessage> =>
+			makeAssistant(
+				[makeToolCall("c_loop", "search_corpus", { query: "loop" })],
+				"toolUse",
+			);
+
+		const driver = rlmDriver({
+			model: MODEL,
+			tools: { registry, maxToolIterations: 3 },
+			toolsLlm,
+		});
+
+		const events = await drain(
+			runAgent({
+				agentId: "t",
+				sessionId: "s-loop-cap",
+				input: "loop forever",
+				driver,
+				toolRegistry: registry,
+			}),
+		);
+
+		const err = events.find(
+			(e) =>
+				e.type === "Error" &&
+				(e as { phase: string }).phase === "driver",
+		) as { error: { message: string } } | undefined;
+		assert.ok(err);
+		assert.match(err?.error?.message ?? "", /maxToolIterations/);
+	});
+
+	it("expose allowlist limits tools offered to the LLM", async () => {
+		const registry = createToolRegistry();
+		registry.register("search_corpus", async () => [], SEARCH_SCHEMA);
+		registry.register("read", async () => "", READ_SCHEMA);
+		registry.register("propose_yaml", async () => null, {
+			description: "Stage a yaml draft for review",
+			parameters: {
+				type: "object",
+				properties: { path: { type: "string" } },
+				required: ["path"],
+			},
+		});
+
+		const seen: PiContext[] = [];
+		const toolsLlm = async (ctx: PiContext): Promise<PiAssistantMessage> => {
+			seen.push(ctx);
+			return makeAssistant([{ type: "text", text: "ok" }]);
+		};
+
+		const driver = rlmDriver({
+			model: MODEL,
+			tools: {
+				registry,
+				expose: ["read", "propose_yaml"], // search_corpus is hidden
+			},
+			toolsLlm,
+		});
+
+		await drain(
+			runAgent({
+				agentId: "t",
+				sessionId: "s-expose",
+				input: "go",
+				driver,
+				toolRegistry: registry,
+			}),
+		);
+
+		const offered = (seen[0]?.tools ?? []).map((t) => t.name);
+		assert.deepEqual(offered, ["read", "propose_yaml"]);
+	});
+
+	it("interim text between tool calls surfaces as Message events", async () => {
+		const registry = createToolRegistry();
+		registry.register("search_corpus", async () => [], SEARCH_SCHEMA);
+
+		let call = 0;
+		const toolsLlm = async (): Promise<PiAssistantMessage> => {
+			call++;
+			if (call === 1) {
+				return makeAssistant(
+					[
+						{ type: "text", text: "Let me search first." },
+						makeToolCall("c1", "search_corpus", { query: "x" }),
+					],
+					"toolUse",
+				);
+			}
+			return makeAssistant([{ type: "text", text: "Done searching." }]);
+		};
+
+		const driver = rlmDriver({
+			model: MODEL,
+			tools: { registry },
+			toolsLlm,
+		});
+
+		const events = await drain(
+			runAgent({
+				agentId: "t",
+				sessionId: "s-interim",
+				input: "go",
+				driver,
+				toolRegistry: registry,
+			}),
+		);
+
+		const messages = events.filter((e) => e.type === "Message") as Array<{
+			content: string;
+		}>;
+		const contents = messages.map((m) => m.content);
+		assert.ok(contents.includes("Let me search first."));
+		assert.ok(contents.includes("Done searching."));
+	});
+});
+
+describe("rlmDriver tier-2 integration — brain tools stub end-to-end", () => {
+	it("search → read → propose_yaml → final answer pipeline works", async () => {
+		// This is the "Tier 2 brain-consuming agent" pattern from
+		// brain's runbook/custom-rlmx-agents.md — the flow the issue
+		// calls out as the killer use case. Stubs stand in for the
+		// real brain_tools.py handlers.
+		const registry = createToolRegistry();
+		const searchCalls: unknown[] = [];
+		const readCalls: unknown[] = [];
+		const proposeCalls: unknown[] = [];
+
+		registry.register(
+			"search_corpus",
+			async (args) => {
+				searchCalls.push(args);
+				return { hits: [{ id: "entry_42", score: 0.91 }] };
+			},
+			SEARCH_SCHEMA,
+		);
+		registry.register(
+			"read",
+			async (args) => {
+				readCalls.push(args);
+				return {
+					id: "entry_42",
+					title: "diego fernandes",
+					body: "client since 2024-06",
+				};
+			},
+			READ_SCHEMA,
+		);
+		registry.register(
+			"propose_yaml",
+			async (args) => {
+				proposeCalls.push(args);
+				return { staged: true, path: "_pending/2026-04-23/diego.md" };
+			},
+			{
+				description: "Stage a yaml proposal under _pending/",
+				parameters: {
+					type: "object",
+					properties: {
+						path: { type: "string" },
+						content: { type: "string" },
+					},
+					required: ["path", "content"],
+				},
+			},
+		);
+
+		let turn = 0;
+		const toolsLlm = async (): Promise<PiAssistantMessage> => {
+			turn++;
+			if (turn === 1) {
+				return makeAssistant(
+					[makeToolCall("c1", "search_corpus", { query: "diego" })],
+					"toolUse",
+				);
+			}
+			if (turn === 2) {
+				return makeAssistant(
+					[makeToolCall("c2", "read", { id: "entry_42" })],
+					"toolUse",
+				);
+			}
+			if (turn === 3) {
+				return makeAssistant(
+					[
+						makeToolCall("c3", "propose_yaml", {
+							path: "_pending/2026-04-23/diego.md",
+							content: "name: Diego Fernandes",
+						}),
+					],
+					"toolUse",
+				);
+			}
+			return makeAssistant([
+				{
+					type: "text",
+					text: "Staged proposal at _pending/2026-04-23/diego.md",
+				},
+			]);
+		};
+
+		const driver = rlmDriver({
+			model: MODEL,
+			tools: { registry },
+			toolsLlm,
+		});
+
+		const events = await drain(
+			runAgent({
+				agentId: "tier2-test",
+				sessionId: "s-tier2",
+				input: "extract diego's contact entry",
+				driver,
+				toolRegistry: registry,
+			}),
+		);
+
+		// All three tools were actually invoked.
+		assert.deepEqual(searchCalls, [{ query: "diego" }]);
+		assert.deepEqual(readCalls, [{ id: "entry_42" }]);
+		assert.equal(proposeCalls.length, 1);
+
+		// Run completed cleanly.
+		const close = events.find((e) => e.type === "SessionClose") as
+			| { reason: string }
+			| undefined;
+		assert.equal(close?.reason, "complete");
+
+		// emit_done payload carries the final answer.
+		const emitDone = events.find((e) => e.type === "EmitDone") as
+			| { payload: { answer: string; toolCalls: number } }
+			| undefined;
+		assert.ok(emitDone);
+		assert.match(
+			emitDone?.payload?.answer ?? "",
+			/_pending\/2026-04-23\/diego\.md/,
+		);
+		assert.equal(emitDone?.payload?.toolCalls, 3);
+
+		// ToolCallBefore/After events bracket each dispatch, in order.
+		const beforeNames = events
+			.filter((e) => e.type === "ToolCallBefore")
+			.map((e) => (e as { tool: string }).tool);
+		assert.deepEqual(beforeNames, ["search_corpus", "read", "propose_yaml"]);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #78. rlmDriver now dispatches native function-calling tools, unblocking Tier 2 brain-consuming agents.

### Problem

Previously `rlmDriver` called `llmCompleteSimple()` once per iteration and surfaced the entire response as `emit_done.payload`. The LLM could emit tool-call blocks, but they were never parsed/dispatched against the `ToolRegistry` passed to `runAgent`. Consumers wanting iterative reasoning (`search_corpus` → `read` → `propose_yaml`) had to pre-fetch context, write their own driver, or fork the SDK.

### What changed

- **`ToolRegistry.register(name, handler, schema?)`** — tools can now declare `{description, parameters}` JSON-Schema metadata. Tools without schemas stay dispatchable but aren't exposed to the LLM as callable functions (safe default).
- **`IterationDriver`** — widened to an `AsyncGenerator` so runAgent can feed `ToolCallOutcome` back via `yield`'s return value. Existing legacy drivers ignore the pushed value; no breaking change.
- **`rlmDriver` tool-dispatch mode** (new, opt-in via `tools: { registry }` config):
  - Builds a pi-ai `Tool[]` from the registry's schemas — pi-ai handles the per-provider shape (Gemini `functionDeclarations`, Anthropic `tools`, OpenAI `functions`).
  - Calls pi-ai `completeSimple` with native function-calling enabled.
  - Yields a `tool_call` step per `ToolCall` block, awaits the outcome, appends a `toolResult` to pi-ai history, loops.
  - Terminates on pure-text response OR explicit `emit_done` tool call OR `maxToolIterations` cap (default 16).
  - Surfaces interim text between tool calls as `Message` events.
  - Feeds tool errors + permission denials back to the LLM as `isError: true` results rather than aborting.
- **Legacy one-shot path preserved byte-compatibly** — no `tools` config, no behavior change.
- runAgent's permission chain, validate retry pipeline, session checkpoints all continue to fire.

### Scope boundaries (per issue)

- ✅ Gemini native function-calling (priority 1) — validated live.
- ✅ Anthropic + OpenAI — inherited via pi-ai's per-provider normalization. Not live-smoke tested here; pi-ai already ships convertTools for each.
- ⛔ Python REPL executor for rlmx-specific tool-call code blocks — explicitly out of scope per issue, separate larger slice.

### New types exported

- `ToolSchema`, `ToolCallOutcome`, `RlmDriverToolsConfig`

## Test plan

- [x] Typecheck: `bun run check` clean.
- [x] Full suite: `node --test dist/tests/*.test.js` → 356/356 pass (10 new tests in `sdk-rlm-driver-tools.test.ts`, 0 existing tests broken).
- [x] Live smoke against Gemini 2.5 Flash — single tool (`get_weather`): LLM chose the tool, runAgent dispatched, result fed back, final answer synthesized.
- [x] Live smoke against Gemini 2.5 Flash — multi-tool iterative (`search_corpus` → `read` → synthesize): the exact Tier 2 pattern the issue called out as impossible. Both tools invoked in order, final answer cites entry id.

### New test coverage

| Test | What it proves |
|---|---|
| `no schemas in registry → falls back to legacy one-shot mode` | Safe default: registry with handlers-only doesn't accidentally engage tool-dispatch |
| `single tool call → yields tool_call step with name, args, id` | Step shape matches runAgent dispatch contract |
| `multiple tool calls in one assistant response → yielded sequentially` | Parallel tool-call blocks dispatched one at a time (safer for permission state) |
| `tool error outcome → driver feeds error text back to LLM, not abort` | Graceful error recovery; LLM sees `isError: true` result |
| `permission-denied outcome → driver surfaces denial to LLM` | Permission chain integration works end-to-end |
| `emit_done tool call short-circuits → payload becomes the emit_done payload` | Structured exit path via tool rather than text |
| `maxToolIterations cap → driver yields error when LLM keeps calling tools` | Infinite-loop guard |
| `expose allowlist limits tools offered to the LLM` | Per-agent tool scoping works |
| `interim text between tool calls surfaces as Message events` | Observability: reasoning between tool dispatches is visible |
| `search → read → propose_yaml → final answer pipeline works` | Tier 2 brain-consuming agent pattern end-to-end |