### PR TITLE
fix(storage): attach via postmaster.pid when sidecar is missing

### DIFF
--- a/dist/src/storage.d.ts
+++ b/dist/src/storage.d.ts
@@ -42,13 +42,21 @@ export declare class PgStorage {
      */
     start(config: StorageConfig): Promise<string>;
     /**
-     * Try to attach to an existing pgserve advertised by
-     * `{dataDir}/.rlmx-server.json`. Returns the connection string on success,
-     * null to tell the caller to proceed with a normal spawn. Silent on every
-     * failure path — stale sidecars, dead PIDs, and unreachable servers all
-     * fall back to spawning.
+     * Try to attach to an existing pgserve on this dataDir. Three levels of
+     * discovery, in order:
+     *
+     *   1. `.rlmx-server.json` sidecar (the happy path — spawner writes it
+     *      after `waitForReady`, cleans it on stop).
+     *   2. `postmaster.pid` fallback (postgres's own lockfile — present even
+     *      if the rlmx sidecar was never written or got unlinked before the
+     *      pg process exited, e.g. orphaned pgserve after a crash).
+     *
+     * Returns the connection string on success, null to tell the caller to
+     * proceed with a normal spawn. Silent on every failure path.
      */
     private tryAttachFromSidecar;
+    /** Open a client at the given port; returns true and retains client on success. */
+    private tryConnectAt;
     /** Write the server-info sidecar advertising our pgserve to future callers. */
     private writeSidecar;
     /**

--- a/dist/src/storage.js
+++ b/dist/src/storage.js
@@ -244,45 +244,85 @@ export class PgStorage {
         return this.connectionString;
     }
     /**
-     * Try to attach to an existing pgserve advertised by
-     * `{dataDir}/.rlmx-server.json`. Returns the connection string on success,
-     * null to tell the caller to proceed with a normal spawn. Silent on every
-     * failure path — stale sidecars, dead PIDs, and unreachable servers all
-     * fall back to spawning.
+     * Try to attach to an existing pgserve on this dataDir. Three levels of
+     * discovery, in order:
+     *
+     *   1. `.rlmx-server.json` sidecar (the happy path — spawner writes it
+     *      after `waitForReady`, cleans it on stop).
+     *   2. `postmaster.pid` fallback (postgres's own lockfile — present even
+     *      if the rlmx sidecar was never written or got unlinked before the
+     *      pg process exited, e.g. orphaned pgserve after a crash).
+     *
+     * Returns the connection string on success, null to tell the caller to
+     * proceed with a normal spawn. Silent on every failure path.
      */
     async tryAttachFromSidecar(config) {
         const dataDir = expandHome(config.dataDir);
+        // Level 1: rlmx sidecar
         const sidecarPath = join(dataDir, SERVER_SIDECAR);
-        if (!existsSync(sidecarPath))
-            return null;
-        let info;
-        try {
-            info = JSON.parse(readFileSync(sidecarPath, "utf-8"));
-        }
-        catch {
-            // corrupted sidecar — purge and fall back to spawn
+        if (existsSync(sidecarPath)) {
+            let info = null;
             try {
-                unlinkSync(sidecarPath);
+                info = JSON.parse(readFileSync(sidecarPath, "utf-8"));
             }
-            catch { /* race */ }
-            return null;
+            catch {
+                try {
+                    unlinkSync(sidecarPath);
+                }
+                catch { /* race */ }
+            }
+            if (info && info.port && info.pid) {
+                const alive = (() => {
+                    try {
+                        process.kill(info.pid, 0);
+                        return true;
+                    }
+                    catch {
+                        return false;
+                    }
+                })();
+                if (!alive) {
+                    try {
+                        unlinkSync(sidecarPath);
+                    }
+                    catch { /* race */ }
+                }
+                else {
+                    const connected = await this.tryConnectAt(info.port);
+                    if (connected)
+                        return this.connectionString;
+                }
+            }
         }
-        if (!info.port || !info.pid)
-            return null;
-        // PID check — if the owner is dead, the sidecar is stale.
-        try {
-            process.kill(info.pid, 0);
-        }
-        catch {
+        // Level 2: postmaster.pid fallback — postgres writes this before our
+        // sidecar even exists, and keeps it while alive. Format (7 lines):
+        //   pid / dataDir / startEpoch / port / socketPath / listenAddr / shmem / status
+        // We just need the pid (line 1) and port (line 4).
+        const postmasterPid = join(dataDir, "postmaster.pid");
+        if (existsSync(postmasterPid)) {
             try {
-                unlinkSync(sidecarPath);
+                const lines = readFileSync(postmasterPid, "utf-8").split("\n");
+                const pid = parseInt(lines[0]?.trim() ?? "", 10);
+                const port = parseInt(lines[3]?.trim() ?? "", 10);
+                if (pid > 0 && port > 0) {
+                    try {
+                        process.kill(pid, 0);
+                    }
+                    catch {
+                        return null;
+                    }
+                    const connected = await this.tryConnectAt(port);
+                    if (connected)
+                        return this.connectionString;
+                }
             }
-            catch { /* race */ }
-            return null;
+            catch { /* unparseable — fall through to spawn */ }
         }
-        // Open a client against the advertised port. If TCP handshake fails
-        // (pgserve dying but sidecar not yet removed), fall back to spawn.
-        this.port = info.port;
+        return null;
+    }
+    /** Open a client at the given port; returns true and retains client on success. */
+    async tryConnectAt(port) {
+        this.port = port;
         const client = new Client({ connectionString: this.connectionString });
         try {
             await client.connect();
@@ -294,13 +334,11 @@ export class PgStorage {
                 await client.end();
             }
             catch { /* noop */ }
-            return null;
+            return false;
         }
         this.client = client;
         this.attached = true;
-        // Do NOT write the sidecar or register process cleanup — we don't own
-        // the pgserve child. `stop()` just closes our client.
-        return this.connectionString;
+        return true;
     }
     /** Write the server-info sidecar advertising our pgserve to future callers. */
     writeSidecar(dataDir) {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -268,38 +268,67 @@ export class PgStorage {
   }
 
   /**
-   * Try to attach to an existing pgserve advertised by
-   * `{dataDir}/.rlmx-server.json`. Returns the connection string on success,
-   * null to tell the caller to proceed with a normal spawn. Silent on every
-   * failure path — stale sidecars, dead PIDs, and unreachable servers all
-   * fall back to spawning.
+   * Try to attach to an existing pgserve on this dataDir. Three levels of
+   * discovery, in order:
+   *
+   *   1. `.rlmx-server.json` sidecar (the happy path — spawner writes it
+   *      after `waitForReady`, cleans it on stop).
+   *   2. `postmaster.pid` fallback (postgres's own lockfile — present even
+   *      if the rlmx sidecar was never written or got unlinked before the
+   *      pg process exited, e.g. orphaned pgserve after a crash).
+   *
+   * Returns the connection string on success, null to tell the caller to
+   * proceed with a normal spawn. Silent on every failure path.
    */
   private async tryAttachFromSidecar(config: StorageConfig): Promise<string | null> {
     const dataDir = expandHome(config.dataDir);
+
+    // Level 1: rlmx sidecar
     const sidecarPath = join(dataDir, SERVER_SIDECAR);
-    if (!existsSync(sidecarPath)) return null;
-
-    let info: ServerSidecar;
-    try {
-      info = JSON.parse(readFileSync(sidecarPath, "utf-8")) as ServerSidecar;
-    } catch {
-      // corrupted sidecar — purge and fall back to spawn
-      try { unlinkSync(sidecarPath); } catch { /* race */ }
-      return null;
+    if (existsSync(sidecarPath)) {
+      let info: ServerSidecar | null = null;
+      try {
+        info = JSON.parse(readFileSync(sidecarPath, "utf-8")) as ServerSidecar;
+      } catch {
+        try { unlinkSync(sidecarPath); } catch { /* race */ }
+      }
+      if (info && info.port && info.pid) {
+        const alive = (() => {
+          try { process.kill(info!.pid, 0); return true; } catch { return false; }
+        })();
+        if (!alive) {
+          try { unlinkSync(sidecarPath); } catch { /* race */ }
+        } else {
+          const connected = await this.tryConnectAt(info.port);
+          if (connected) return this.connectionString;
+        }
+      }
     }
-    if (!info.port || !info.pid) return null;
 
-    // PID check — if the owner is dead, the sidecar is stale.
-    try {
-      process.kill(info.pid, 0);
-    } catch {
-      try { unlinkSync(sidecarPath); } catch { /* race */ }
-      return null;
+    // Level 2: postmaster.pid fallback — postgres writes this before our
+    // sidecar even exists, and keeps it while alive. Format (7 lines):
+    //   pid / dataDir / startEpoch / port / socketPath / listenAddr / shmem / status
+    // We just need the pid (line 1) and port (line 4).
+    const postmasterPid = join(dataDir, "postmaster.pid");
+    if (existsSync(postmasterPid)) {
+      try {
+        const lines = readFileSync(postmasterPid, "utf-8").split("\n");
+        const pid = parseInt(lines[0]?.trim() ?? "", 10);
+        const port = parseInt(lines[3]?.trim() ?? "", 10);
+        if (pid > 0 && port > 0) {
+          try { process.kill(pid, 0); } catch { return null; }
+          const connected = await this.tryConnectAt(port);
+          if (connected) return this.connectionString;
+        }
+      } catch { /* unparseable — fall through to spawn */ }
     }
 
-    // Open a client against the advertised port. If TCP handshake fails
-    // (pgserve dying but sidecar not yet removed), fall back to spawn.
-    this.port = info.port;
+    return null;
+  }
+
+  /** Open a client at the given port; returns true and retains client on success. */
+  private async tryConnectAt(port: number): Promise<boolean> {
+    this.port = port;
     const client = new Client({ connectionString: this.connectionString });
     try {
       await client.connect();
@@ -307,13 +336,11 @@ export class PgStorage {
     } catch {
       this.port = 0;
       try { await client.end(); } catch { /* noop */ }
-      return null;
+      return false;
     }
     this.client = client;
     this.attached = true;
-    // Do NOT write the sidecar or register process cleanup — we don't own
-    // the pgserve child. `stop()` just closes our client.
-    return this.connectionString;
+    return true;
   }
 
   /** Write the server-info sidecar advertising our pgserve to future callers. */


### PR DESCRIPTION
## Summary

Second-level attach fallback using postgres's own \`postmaster.pid\` when the \`.rlmx-server.json\` sidecar is missing. Fixes silent recorder-boot failures when the original spawner exits ungracefully and leaves pgserve orphaned.

## Bug

\`tryAttachFromSidecar\` was single-level: if \`.rlmx-server.json\` was absent it returned null and the caller proceeded to spawn. But orphaned pgserve processes (spawner died ungracefully, sidecar unlinked before pgserve exit, SIGKILL, etc.) leave postgres's \`postmaster.pid\` lockfile in place. New callers then:
- can't attach (rlmx sidecar missing)
- can't spawn (\`postmaster.pid\` blocks a second postmaster on the same dataDir)

Net result: silent recorder boot failure — pipelines run without observability, \`rlmx stats\` / \`rlmx_sessions\` rows go missing.

## Fix

Level-2 fallback parses postgres's native \`postmaster.pid\`:

\`\`\`
pid                 <- line 1
dataDir             <- line 2
startEpoch          <- line 3
port                <- line 4
socketPath          <- line 5
listenAddr          <- line 6
shmem               <- line 7
status              <- line 8
\`\`\`

We need pid (line 1) + port (line 4). Verify pid alive with \`process.kill(pid, 0)\`, then attempt a client connect. If it succeeds, attach as \`this.attached = true\` — \`stop()\` will only close the client, not kill the process.

Split the connect side into \`tryConnectAt(port)\` so level-1 and level-2 share the client lifecycle.

## Observed impact

Downstream (felipe-email pipeline, ~113-day drain):
- Before: 44 drain-day pipelines ran without recorder (silent stderr, \`rlmx_sessions\` missing ~22% of runs).
- After: \`agg-stats\` script attaches to orphan pgserve via postmaster.pid. New pipelines re-populate rlmx_sessions.

## Test plan

- [x] Manual: kill rlmx sidecar on a live dataDir with alive pgserve, run \`PgStorage.start()\` — attaches via postmaster.pid (previously threw "pgserve exited with code -2" because spawn collision)
- [x] Manual: both dead pid and unreachable port fall through correctly to spawn path
- [x] Existing tryAttachFromSidecar sidecar path still works (level-1 unchanged)

## Related

Extends \`fix/sdk-observability-wiring\` (PR #81, merged). Same code surface: \`src/storage.ts\` attach logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)