### PR TITLE
ci(version): swap to npm OIDC trusted publishing (mirror genie)

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,5 +1,26 @@
 name: Version
 
+# Single source of npm publishing for @automagik/rlmx.
+#
+#   Trigger                              Context  npm tag   Bump?
+#   -----------------------------------  -------  --------  ------
+#   workflow_run (CI success on dev)     dev      @next     yes
+#   workflow_run (merge PR to main)      main     @latest   no
+#   workflow_dispatch (manual)           dev      @next     yes
+#
+# On dev triggers we DERIVE a fresh version (today + build-count),
+# commit + tag + push back to dev, then publish as @next.
+#
+# On main triggers (merge from dev) we DO NOT bump — the version that
+# dev already tagged is in package.json. We just publish that exact
+# version as @latest, so npm and GitHub Release agree. Bumping on main
+# caused historical drift between release tag and npm latest.
+#
+# Auth: npm OIDC Trusted Publishing. The package's only Trusted
+# Publisher entry on npmjs.com is THIS file (version.yml). All other
+# workflows defer to this one for npm publishing. Mirrors the genie
+# repo's setup (genie/.github/workflows/version.yml).
+
 on:
   workflow_run:
     workflows: ["CI"]
@@ -9,6 +30,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write   # required for npm OIDC trusted-publisher token exchange
 
 concurrency:
   group: version-${{ github.event.workflow_run.head_branch || 'manual' }}
@@ -23,6 +45,7 @@ jobs:
       (github.event_name == 'workflow_dispatch') ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
+       !contains(github.event.workflow_run.head_commit.message, '[auto-version]') &&
        !contains(github.event.workflow_run.head_commit.message, '[skip ci]') &&
        (
          (github.event.workflow_run.head_branch == 'main' &&
@@ -37,13 +60,19 @@ jobs:
         id: context
         run: |
           BRANCH="${{ github.event.workflow_run.head_branch || 'dev' }}"
-          echo "branch=dev" >> "$GITHUB_OUTPUT"
-          echo "prefix=0" >> "$GITHUB_OUTPUT"
           if [ "$BRANCH" = "main" ]; then
+            # Main push: publish whatever dev already tagged. Do NOT bump.
+            echo "branch=main" >> "$GITHUB_OUTPUT"
             echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+            echo "should_bump=false" >> "$GITHUB_OUTPUT"
           else
+            # Dev push (or manual dispatch): derive + bump + publish @next.
+            echo "branch=dev" >> "$GITHUB_OUTPUT"
             echo "npm_tag=next" >> "$GITHUB_OUTPUT"
+            echo "should_bump=true" >> "$GITHUB_OUTPUT"
           fi
+          echo "prefix=0" >> "$GITHUB_OUTPUT"
+          echo "Resolved: branch=${BRANCH}"
 
       - uses: actions/checkout@v4
         with:
@@ -55,17 +84,20 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Configure git
+        if: steps.context.outputs.should_bump == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Derive version
         id: version
+        if: steps.context.outputs.should_bump == 'true'
         run: |
           PREFIX="${{ steps.context.outputs.prefix }}"
           TODAY=$(date -u +%y%m%d)
@@ -77,11 +109,13 @@ jobs:
           echo "Derived version: ${VERSION}"
 
       - name: Sync all version files
+        if: steps.context.outputs.should_bump == 'true'
         run: npm run bump-version
         env:
           RLMX_BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
 
       - name: Commit and tag
+        if: steps.context.outputs.should_bump == 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH="${{ steps.context.outputs.branch }}"
@@ -90,22 +124,45 @@ jobs:
           if git diff --cached --quiet; then
             echo "No version changes to commit"
           else
-            git commit -m "chore(version): bump to ${VERSION} [skip ci]"
+            git commit -m "chore(version): bump to ${VERSION} [auto-version]"
           fi
 
           git tag "v${VERSION}"
           git push --atomic origin "HEAD:refs/heads/${BRANCH}" "refs/tags/v${VERSION}"
 
+      # On main context we publish whatever package.json currently holds —
+      # that's the version dev tagged on the same chain, which is exactly
+      # what @latest should point at.
+      - name: Resolve publish version
+        id: pubver
+        run: |
+          if [ "${{ steps.context.outputs.should_bump }}" = "true" ]; then
+            VERSION="${{ steps.version.outputs.version }}"
+          else
+            VERSION=$(jq -r '.version' package.json)
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${VERSION} with tag ${{ steps.context.outputs.npm_tag }}"
+
       - name: Build
         run: npm run build
 
-      - name: Publish to npm
+      # Node 22 bundles npm 10.x; npm Trusted Publishing (automatic OIDC
+      # token exchange) requires npm >= 11.5.1. Without this upgrade,
+      # `npm publish` sends an empty placeholder token and the registry
+      # returns a misleading 404 instead of the real 401/403 auth failure.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Publish to npm via OIDC
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "NPM_TOKEN not set — skipping publish"
-            exit 0
-          fi
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          npm publish --access public --tag ${{ steps.context.outputs.npm_tag }}
+          # npm auto-enables provenance in any CI env with `id-token: write`.
+          # On Blacksmith runners the server-side sigstore check fails with
+          # 422; on GitHub-hosted runners (this workflow) it usually works,
+          # but disable it explicitly to keep the contract identical to genie
+          # and avoid surprise failures. OIDC token exchange still happens.
+          NPM_CONFIG_PROVENANCE: "false"
+        # On main context: publish package.json's current version as @latest
+        # (no bump, matches what dev already tagged).
+        # On dev context: publish the version we just bumped to as @next.
+        run: npm publish --access public --tag ${{ steps.context.outputs.npm_tag }}


### PR DESCRIPTION
## Summary

Replaces NPM_TOKEN-based publishing with npm Trusted Publisher (OIDC token exchange). Mirrors the pattern in `automagik-dev/genie/.github/workflows/version.yml` so both repos use the same supply-chain story.

## Why

We swapped to OIDC trusted publishing for genie because we no longer want long-lived npm API keys living in repo secrets. rlmx was still on the legacy NPM_TOKEN path. Felt's call: copy the same setup.

## What changed

- Added \`permissions.id-token: write\` so GitHub Actions can mint the OIDC token npm needs for trusted-publisher exchange.
- Removed \`NPM_TOKEN\` block and \`~/.npmrc\` write — no static auth anywhere.
- Added \`registry-url\` to setup-node so the publish call hits npmjs.org explicitly.
- Upgrade npm to latest before publish (Node 22 ships npm 10.x; OIDC trusted publishing needs npm >= 11.5.1, otherwise the publish call sends an empty placeholder token and the registry returns a misleading 404 instead of the real 401/403).
- Set \`NPM_CONFIG_PROVENANCE=false\` to keep behavior identical to genie's workflow and avoid the Blacksmith 422 surprise (we're on ubuntu-latest here so it usually works, but explicit > implicit).
- Adopted genie's \`should_bump\` logic: bump+tag on dev pushes, but on main merges publish package.json's existing version as @latest with NO bump. This is the fix for the GitHub-Release-tag-vs-npm-latest drift bug that hit genie on 2026-04-23 (release v4.260423.9 vs npm latest 4.260423.10).
- Added \`[auto-version]\` skip filter so our own bump commit doesn't recursively retrigger the workflow.

## Setup checklist (npm side, one-time)

1. https://www.npmjs.com/package/@automagik/rlmx → Settings → Trusted Publisher
2. Provider: GitHub Actions
3. Organization: \`automagik-dev\`
4. Repository: \`rlmx\`
5. Workflow filename: \`version.yml\`
6. Environment name: (leave empty — we publish from the workflow directly, no GitHub environment gating needed since you're the sole maintainer)

Once that entry is saved on npmjs.com:
- Pushes to \`dev\` fire CI → version.yml → OIDC exchange → publish as \`@next\`
- PR merges to \`main\` fire CI → version.yml → publish same version as \`@latest\` (no bump)

## Test plan

- [ ] Merge this PR to dev
- [ ] Verify CI runs green
- [ ] Verify version.yml fires after CI completes
- [ ] Verify it publishes as \`@next\` to npm via OIDC (no NPM_TOKEN error in logs)
- [ ] Then merge dev → main (rlmx PR #77 already open)
- [ ] Verify version.yml on main fires + publishes as \`@latest\` matching the existing version in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)