### PR TITLE
ci(version): use Node 24 for OIDC publish — fix npm self-upgrade bug

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -80,9 +80,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Node 24 ships npm 11.5+ which has OIDC trusted-publisher support
+      # built in. Avoids the `npm install -g npm@latest` self-upgrade bug
+      # (Arborist clobbering its own promise-retry dep mid-install) that
+      # broke our 0.260425.1 publish on Node 22 + ubuntu-latest.
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -147,12 +151,16 @@ jobs:
       - name: Build
         run: npm run build
 
-      # Node 22 bundles npm 10.x; npm Trusted Publishing (automatic OIDC
-      # token exchange) requires npm >= 11.5.1. Without this upgrade,
-      # `npm publish` sends an empty placeholder token and the registry
-      # returns a misleading 404 instead of the real 401/403 auth failure.
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+      - name: Verify npm version supports OIDC trusted publishing
+        run: |
+          NPM_VERSION=$(npm --version)
+          echo "npm version: ${NPM_VERSION}"
+          # OIDC trusted publishing requires npm >= 11.5.1.
+          MAJOR=$(echo "${NPM_VERSION}" | cut -d. -f1)
+          if [ "${MAJOR}" -lt 11 ]; then
+            echo "::error::npm ${NPM_VERSION} too old — OIDC requires >= 11.5.1. Bump node-version above."
+            exit 1
+          fi
 
       - name: Publish to npm via OIDC
         env:


### PR DESCRIPTION
## Problem

Run [#24935986140](https://github.com/automagik-dev/rlmx/actions/runs/24935986140) failed at the "Upgrade npm for OIDC trusted publishing" step:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`

This is a known npm CLI in-place self-upgrade race: Arborist (npm's dep-tree manager) clobbers its own \`promise-retry\` dep mid-install. Reliably reproducible on \`ubuntu-latest\` + Node 22.

## Fix

Switch from "Node 22 + \`npm install -g npm@latest\`" to **Node 24** which ships npm 11.5+ with OIDC trusted-publisher support built in. Removes the fragile self-upgrade step entirely.

Adds a defensive check that fails fast if the runtime npm doesn't satisfy the OIDC minimum (≥ 11), so future Node downgrades produce a clear error instead of the misleading "404 Not Found" that npm 10 returns when its OIDC token exchange fails silently.

## Test plan

- [ ] Merge to dev
- [ ] Verify dev's CI green
- [ ] Verify version.yml fires + publishes 0.260425.x as @next
- [ ] Then merge dev → main (PR #84 if needed, or amend PR #77 follow-up)
- [ ] Verify main version.yml publishes same version as @latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)