### PR TITLE
Dev → main: Node 24 OIDC publish fix

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -80,9 +80,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Node 24 ships npm 11.5+ which has OIDC trusted-publisher support
+      # built in. Avoids the `npm install -g npm@latest` self-upgrade bug
+      # (Arborist clobbering its own promise-retry dep mid-install) that
+      # broke our 0.260425.1 publish on Node 22 + ubuntu-latest.
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -147,12 +151,16 @@ jobs:
       - name: Build
         run: npm run build
 
-      # Node 22 bundles npm 10.x; npm Trusted Publishing (automatic OIDC
-      # token exchange) requires npm >= 11.5.1. Without this upgrade,
-      # `npm publish` sends an empty placeholder token and the registry
-      # returns a misleading 404 instead of the real 401/403 auth failure.
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+      - name: Verify npm version supports OIDC trusted publishing
+        run: |
+          NPM_VERSION=$(npm --version)
+          echo "npm version: ${NPM_VERSION}"
+          # OIDC trusted publishing requires npm >= 11.5.1.
+          MAJOR=$(echo "${NPM_VERSION}" | cut -d. -f1)
+          if [ "${MAJOR}" -lt 11 ]; then
+            echo "::error::npm ${NPM_VERSION} too old — OIDC requires >= 11.5.1. Bump node-version above."
+            exit 1
+          fi
 
       - name: Publish to npm via OIDC
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/rlmx",
-  "version": "0.260425.1",
+  "version": "0.260425.2",
   "description": "RLM algorithm CLI for coding agents — prompt externalization, Python REPL with symbolic recursion, code-driven navigation",
   "type": "module",
   "publishConfig": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.260425.1';
+export const VERSION = '0.260425.2';


### PR DESCRIPTION
Promotes the Node 24 OIDC publish fix from dev to main.

## Why this PR exists

PR #77 (previous dev→main) merged successfully but the version.yml run on main FAILED at the npm self-upgrade step:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`

PR #84 fixed this on dev by switching from "Node 22 + \`npm install -g npm@latest\`" to **Node 24** (which ships npm 11.5+ with OIDC built-in). But \`workflow_run\` triggers use the workflow file from the **default branch** (main), so the dev fix never executes — until main also has it.

This PR brings main up to dev so version.yml runs the new Node-24-based workflow.

## Diff vs main

\`81659b4\` chore(version): bump to 0.260425.2 [auto-version]
\`49c2495\` ci(version): use Node 24 for OIDC publish — fix npm self-upgrade bug

(Plus everything dev→main brings forward including the original OIDC swap from PR #83.)

## Expected outcome

- Merge to main → CI runs → version.yml triggers with NEW workflow → Node 24 + npm 11.5+ → publishes 0.260425.2 as @latest via OIDC
- npm trusted publisher entry must already be saved (Felipe did this earlier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)