### PR TITLE
fix: suppress JSONL warnings for markdown context

### DIFF
--- a/dist/src/storage.d.ts
+++ b/dist/src/storage.d.ts
@@ -114,5 +114,19 @@ export declare class PgStorage {
     /** Register process exit handlers for cleanup */
     private registerCleanup;
 }
+export interface ParseContextLineOptions {
+    /** Source path for the line, when loaded from a directory context. */
+    source?: string | null;
+}
+/**
+ * Parse a single line of context data.
+ * JSONL parsing is source-aware so markdown/code examples that happen to
+ * start with "{" remain plain text instead of producing noisy warnings.
+ */
+export declare function parseContextLine(line: string, options?: ParseContextLineOptions): {
+    timestamp: string | null;
+    type: string | null;
+    content: string;
+};
 export {};
 //# sourceMappingURL=storage.d.ts.map

--- a/dist/src/storage.js
+++ b/dist/src/storage.js
@@ -389,7 +389,7 @@ export class PgStorage {
                 const { text, source } = batch[j];
                 if (text.trim() === "")
                     continue;
-                const { timestamp, type, content } = parseLine(text);
+                const { timestamp, type, content } = parseContextLine(text, { source });
                 const idx = values.length;
                 placeholders.push(`($${idx + 1}, $${idx + 2}, $${idx + 3}, $${idx + 4}, $${idx + 5}, $${idx + 6})`);
                 values.push(lineNum, timestamp, type, source, sessionId ?? null, content);
@@ -647,11 +647,17 @@ const TIMESTAMP_FIELDS = [
 const TYPE_FIELDS = ["type", "kind", "level", "severity", "category", "event"];
 /**
  * Parse a single line of context data.
- * Tries JSON first (JSONL), falls back to plain text.
+ * JSONL parsing is source-aware so markdown/code examples that happen to
+ * start with "{" remain plain text instead of producing noisy warnings.
  */
-function parseLine(line) {
+export function parseContextLine(line, options = {}) {
     const trimmed = line.trim();
     if (!trimmed.startsWith("{")) {
+        return { timestamp: null, type: null, content: trimmed };
+    }
+    const source = options.source ?? null;
+    const shouldParseJsonl = source === null || source.toLowerCase().endsWith(".jsonl");
+    if (!shouldParseJsonl) {
         return { timestamp: null, type: null, content: trimmed };
     }
     try {
@@ -678,7 +684,7 @@ function parseLine(line) {
         return { timestamp, type, content: trimmed };
     }
     catch {
-        // Malformed JSON — log warning and treat as plain text
+        // Malformed JSONL in an actual JSONL source — log warning and treat as plain text
         process.stderr.write(`rlmx: warning: skipping malformed JSONL line: ${trimmed.slice(0, 80)}...\n`);
         return { timestamp: null, type: null, content: trimmed };
     }

--- a/dist/tests/storage.test.d.ts
+++ b/dist/tests/storage.test.d.ts
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=storage.test.d.ts.map

--- a/dist/tests/storage.test.js
+++ b/dist/tests/storage.test.js
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseContextLine } from "../src/storage.js";
+function captureStderr(fn) {
+    const originalWrite = process.stderr.write;
+    let captured = "";
+    process.stderr.write = ((chunk) => {
+        captured += String(chunk);
+        return true;
+    });
+    try {
+        fn();
+    }
+    finally {
+        process.stderr.write = originalWrite;
+    }
+    return captured;
+}
+describe("storage context line parsing", () => {
+    it("does not warn for markdown/code lines that look like malformed JSON objects", () => {
+        let parsed;
+        const stderr = captureStderr(() => {
+            parsed = parseContextLine("{ config, ... }: {...", { source: "docs/reference.md" });
+        });
+        assert.equal(stderr, "");
+        assert.deepEqual(parsed, {
+            timestamp: null,
+            type: null,
+            content: "{ config, ... }: {...",
+        });
+    });
+    it("parses JSON object lines from jsonl sources", () => {
+        const parsed = parseContextLine('{"timestamp":"2026-05-16T00:00:00Z","type":"event","message":"ok"}', { source: "events.jsonl" });
+        assert.equal(parsed.timestamp, "2026-05-16T00:00:00Z");
+        assert.equal(parsed.type, "event");
+        assert.equal(parsed.content, '{"timestamp":"2026-05-16T00:00:00Z","type":"event","message":"ok"}');
+    });
+    it("parses JSON object lines from uppercase jsonl sources", () => {
+        const parsed = parseContextLine('{"createdAt":"2026-05-16","kind":"event"}', {
+            source: "EVENTS.JSONL",
+        });
+        assert.equal(parsed.timestamp, "2026-05-16");
+        assert.equal(parsed.type, "event");
+    });
+    it("still warns for malformed JSON lines in jsonl sources", () => {
+        let parsed;
+        const stderr = captureStderr(() => {
+            parsed = parseContextLine("{not valid json", { source: "events.jsonl" });
+        });
+        assert.match(stderr, /malformed JSONL line/);
+        assert.deepEqual(parsed, {
+            timestamp: null,
+            type: null,
+            content: "{not valid json",
+        });
+    });
+});
+//# sourceMappingURL=storage.test.js.map

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -397,7 +397,7 @@ export class PgStorage {
         const { text, source } = batch[j];
         if (text.trim() === "") continue;
 
-        const { timestamp, type, content } = parseLine(text);
+        const { timestamp, type, content } = parseContextLine(text, { source });
         const idx = values.length;
         placeholders.push(
           `($${idx + 1}, $${idx + 2}, $${idx + 3}, $${idx + 4}, $${idx + 5}, $${idx + 6})`
@@ -696,17 +696,32 @@ const TIMESTAMP_FIELDS = [
 /** Common type/category field names in JSONL data */
 const TYPE_FIELDS = ["type", "kind", "level", "severity", "category", "event"];
 
+export interface ParseContextLineOptions {
+  /** Source path for the line, when loaded from a directory context. */
+  source?: string | null;
+}
+
 /**
  * Parse a single line of context data.
- * Tries JSON first (JSONL), falls back to plain text.
+ * JSONL parsing is source-aware so markdown/code examples that happen to
+ * start with "{" remain plain text instead of producing noisy warnings.
  */
-function parseLine(line: string): {
+export function parseContextLine(
+  line: string,
+  options: ParseContextLineOptions = {}
+): {
   timestamp: string | null;
   type: string | null;
   content: string;
 } {
   const trimmed = line.trim();
   if (!trimmed.startsWith("{")) {
+    return { timestamp: null, type: null, content: trimmed };
+  }
+
+  const source = options.source ?? null;
+  const shouldParseJsonl = source === null || source.toLowerCase().endsWith(".jsonl");
+  if (!shouldParseJsonl) {
     return { timestamp: null, type: null, content: trimmed };
   }
 
@@ -736,7 +751,7 @@ function parseLine(line: string): {
 
     return { timestamp, type, content: trimmed };
   } catch {
-    // Malformed JSON — log warning and treat as plain text
+    // Malformed JSONL in an actual JSONL source — log warning and treat as plain text
     process.stderr.write(
       `rlmx: warning: skipping malformed JSONL line: ${trimmed.slice(0, 80)}...\n`
     );

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseContextLine } from "../src/storage.js";
+
+function captureStderr(fn: () => void): string {
+  const originalWrite = process.stderr.write;
+  let captured = "";
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    captured += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    fn();
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+  return captured;
+}
+
+describe("storage context line parsing", () => {
+  it("does not warn for markdown/code lines that look like malformed JSON objects", () => {
+    let parsed: ReturnType<typeof parseContextLine> | undefined;
+    const stderr = captureStderr(() => {
+      parsed = parseContextLine("{ config, ... }: {...", { source: "docs/reference.md" });
+    });
+
+    assert.equal(stderr, "");
+    assert.deepEqual(parsed, {
+      timestamp: null,
+      type: null,
+      content: "{ config, ... }: {...",
+    });
+  });
+
+  it("parses JSON object lines from jsonl sources", () => {
+    const parsed = parseContextLine(
+      '{"timestamp":"2026-05-16T00:00:00Z","type":"event","message":"ok"}',
+      { source: "events.jsonl" }
+    );
+
+    assert.equal(parsed.timestamp, "2026-05-16T00:00:00Z");
+    assert.equal(parsed.type, "event");
+    assert.equal(parsed.content, '{"timestamp":"2026-05-16T00:00:00Z","type":"event","message":"ok"}');
+  });
+
+  it("parses JSON object lines from uppercase jsonl sources", () => {
+    const parsed = parseContextLine('{"createdAt":"2026-05-16","kind":"event"}', {
+      source: "EVENTS.JSONL",
+    });
+
+    assert.equal(parsed.timestamp, "2026-05-16");
+    assert.equal(parsed.type, "event");
+  });
+
+  it("still warns for malformed JSON lines in jsonl sources", () => {
+    let parsed: ReturnType<typeof parseContextLine> | undefined;
+    const stderr = captureStderr(() => {
+      parsed = parseContextLine("{not valid json", { source: "events.jsonl" });
+    });
+
+    assert.match(stderr, /malformed JSONL line/);
+    assert.deepEqual(parsed, {
+      timestamp: null,
+      type: null,
+      content: "{not valid json",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- make storage-mode line parsing source-aware so non-JSONL context files are stored as plain text without malformed JSONL warnings
- preserve JSONL parsing/warnings for unknown-source input and files ending in `.jsonl` / `.JSONL`
- add regression coverage for markdown/code brace-prefixed lines and JSONL behavior

## Root cause
Storage ingestion tried to parse every line beginning with `{` as JSON, regardless of source file type. Markdown/docs corpora often contain brace-prefixed code snippets such as `{ config, ... }`, which were valid plain text but produced noisy `skipping malformed JSONL line` warnings.

## Test plan
- `npm run build`
- `node --test dist/tests/storage.test.js`
- `npm test` — 360 passing

## Notes
This keeps legacy parsing for unknown-source lines, while directory contexts now use the source path to avoid treating `.md` / code docs as JSONL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context data parsing with source-aware format detection to correctly handle JSONL and plain text inputs
  * Enhanced error messages for malformed input to be more specific and informative

* **Tests**
  * Added comprehensive test suite validating context line parsing behavior across documentation, JSON-like, and JSONL input formats with proper error detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/rlmx/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->