### PR TITLE
fix: sync release version artifacts

### DIFF
--- a/dist/src/version.d.ts
+++ b/dist/src/version.d.ts
@@ -1,2 +1,2 @@
-export declare const VERSION = "0.260526.3";
+export declare const VERSION = "0.260526.4";
 //# sourceMappingURL=version.d.ts.map

--- a/dist/src/version.js
+++ b/dist/src/version.js
@@ -1,2 +1,2 @@
-export const VERSION = '0.260526.3';
+export const VERSION = '0.260526.4';
 //# sourceMappingURL=version.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automagik/rlmx",
-  "version": "0.260526.1",
+  "version": "0.260526.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automagik/rlmx",
-      "version": "0.260526.1",
+      "version": "0.260526.4",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.75.5",


### PR DESCRIPTION
## Summary
- sync package-lock root version to package.json 0.260526.4
- rebuild dist version artifacts to 0.260526.4

## Verification
- npm run build
- npm run check
- npm test -- --runInBand (360/360)
- npm audit --audit-level=moderate

Post-merge hygiene follow-up after #89.