### PR TITLE
chore(workflows): add graceful retag fallback to npm publish on version.yml

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -173,4 +173,10 @@ jobs:
         # On main context: publish package.json's current version as @latest
         # (no bump, matches what dev already tagged).
         # On dev context: publish the version we just bumped to as @next.
-        run: npm publish --access public --tag ${{ steps.context.outputs.npm_tag }}
+        run: |
+          VERSION="${{ steps.pubver.outputs.version }}"
+          TAG="${{ steps.context.outputs.npm_tag }}"
+          if ! npm publish --access public --tag "$TAG" 2>&1; then
+            echo "Publish failed (likely already published) — adding dist-tag $TAG..."
+            npm dist-tag add "@automagik/rlmx@${VERSION}" "$TAG"
+          fi

--- a/dist/src/version.d.ts
+++ b/dist/src/version.d.ts
@@ -1,2 +1,2 @@
-export declare const VERSION = "0.260526.4";
+export declare const VERSION = "0.260526.5";
 //# sourceMappingURL=version.d.ts.map

--- a/dist/src/version.js
+++ b/dist/src/version.js
@@ -1,2 +1,2 @@
-export const VERSION = '0.260526.4';
+export const VERSION = '0.260526.5';
 //# sourceMappingURL=version.js.map


### PR DESCRIPTION
Adds try-publish / retag fallback to version.yml so when merging dev into main, if the version was already published on dev, it correctly adds the latest tag on npm rather than failing due to duplicate version errors.