### PR TITLE
chore(release): merge dev into main [npm graceful retag fallback]

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -173,4 +173,10 @@ jobs:
         # On main context: publish package.json's current version as @latest
         # (no bump, matches what dev already tagged).
         # On dev context: publish the version we just bumped to as @next.
-        run: npm publish --access public --tag ${{ steps.context.outputs.npm_tag }}
+        run: |
+          VERSION="${{ steps.pubver.outputs.version }}"
+          TAG="${{ steps.context.outputs.npm_tag }}"
+          if ! npm publish --access public --tag "$TAG" 2>&1; then
+            echo "Publish failed (likely already published) — adding dist-tag $TAG..."
+            npm dist-tag add "@automagik/rlmx@${VERSION}" "$TAG"
+          fi

--- a/dist/src/version.d.ts
+++ b/dist/src/version.d.ts
@@ -1,2 +1,2 @@
-export declare const VERSION = "0.260526.4";
+export declare const VERSION = "0.260526.5";
 //# sourceMappingURL=version.d.ts.map

--- a/dist/src/version.js
+++ b/dist/src/version.js
@@ -1,2 +1,2 @@
-export const VERSION = '0.260526.4';
+export const VERSION = '0.260526.5';
 //# sourceMappingURL=version.js.map


### PR DESCRIPTION
Merging dev into main to include the graceful npm retag fallback in version.yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the npm publishing workflow to gracefully handle re-publication scenarios by adding a fallback mechanism that updates package tags instead of failing when a version is already published.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/automagik-dev/rlmx/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->