### PR TITLE
fix: allow main version publishing after squash merges

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -11,10 +11,11 @@ name: Version
 # On dev triggers we DERIVE a fresh version (today + build-count),
 # commit + tag + push back to dev, then publish as @next.
 #
-# On main triggers (merge from dev) we DO NOT bump — the version that
+# On main triggers we DO NOT bump — the version that
 # dev already tagged is in package.json. We just publish that exact
 # version as @latest, so npm and GitHub Release agree. Bumping on main
-# caused historical drift between release tag and npm latest.
+# caused historical drift between release tag and npm latest. Any green
+# main push is eligible; protected main is the release boundary.
 #
 # Auth: npm OIDC Trusted Publishing. The package's only Trusted
 # Publisher entry on npmjs.com is THIS file (version.yml). All other
@@ -48,11 +49,9 @@ jobs:
        !contains(github.event.workflow_run.head_commit.message, '[auto-version]') &&
        !contains(github.event.workflow_run.head_commit.message, '[skip ci]') &&
        (
-         (github.event.workflow_run.head_branch == 'main' &&
-          startsWith(github.event.workflow_run.head_commit.message, 'Merge pull request') &&
-          contains(github.event.workflow_run.head_commit.message, '/dev'))
+         github.event.workflow_run.head_branch == 'main'
          ||
-         (github.event.workflow_run.head_branch == 'dev')
+         github.event.workflow_run.head_branch == 'dev'
        ))
 
     steps:


### PR DESCRIPTION
## Summary
- allow successful main CI pushes to trigger the Version workflow regardless of whether the merge commit text starts with "Merge pull request"
- keeps dev behavior unchanged and still blocks [auto-version]/[skip ci]

## Why
PR #96 was squash-merged with a release-style subject, so the Version workflow skipped and npm @latest did not move.

## Proof
- YAML syntax check from patch tool passed