### PR TITLE
chore(version): bump to 0.260528.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automagik/rlmx",
-  "version": "0.260528.1",
+  "version": "0.260528.2",
   "description": "RLM algorithm CLI for coding agents — prompt externalization, Python REPL with symbolic recursion, code-driven navigation",
   "type": "module",
   "publishConfig": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '0.260528.1';
+export const VERSION = '0.260528.2';


### PR DESCRIPTION
## Summary
Bump main package version to a fresh unpublished version so the Version workflow can publish @latest via OIDC.

## Why
npm OIDC publish already created @next 0.260528.1. The main duplicate-publish fallback tried npm dist-tag add, but that path cannot authenticate with the trusted-publishing token. A fresh main version avoids the retag path and publishes @latest directly.

## Proof
- npm view currently shows @next=0.260528.1 and @latest still old
- version files updated by npm run bump-version