### PR TITLE
chore: sync generated version artifacts

### DIFF
--- a/dist/src/version.d.ts
+++ b/dist/src/version.d.ts
@@ -1,2 +1,2 @@
-export declare const VERSION = "0.260526.6";
+export declare const VERSION = "0.260528.2";
 //# sourceMappingURL=version.d.ts.map

--- a/dist/src/version.js
+++ b/dist/src/version.js
@@ -1,2 +1,2 @@
-export const VERSION = '0.260526.6';
+export const VERSION = '0.260528.2';
 //# sourceMappingURL=version.js.map

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@automagik/rlmx",
-  "version": "0.260526.4",
+  "version": "0.260528.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@automagik/rlmx",
-      "version": "0.260526.4",
+      "version": "0.260528.2",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-ai": "0.75.5",


### PR DESCRIPTION
## Summary
- Sync generated dist version artifacts with package.json version 0.260528.2
- Sync package-lock root version metadata after npm install/build on prod branch

## Test Plan
- npm run build
- npm test (366 passing)
- npm run check

## Notes
- Branch was clean before npm install; initial build failed because node_modules was stale/missing @earendil-works/pi-ai. npm install restored dependencies and surfaced only version metadata drift.