### PR TITLE
fix: address RLMX release channel review feedback

### DIFF
--- a/dist/src/cli.js
+++ b/dist/src/cli.js
@@ -830,7 +830,8 @@ async function runUpdate(args) {
         return;
     }
     runGit(root, ["reset", "--hard", "origin/main"]);
-    runCommand(root, "npm", ["ci"]);
+    runGit(root, ["clean", "-fd"]);
+    runCommand(root, "npm", ["ci", "--include=dev"]);
     runCommand(root, "npm", ["run", "build"]);
     const after = runGit(root, ["rev-parse", "HEAD"]);
     const { createRequire } = await import("node:module");

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,9 +16,11 @@ mkdir -p "$RLMX_BIN_DIR" "$(dirname "$RLMX_INSTALL_DIR")"
 
 if [ -d "$RLMX_INSTALL_DIR/.git" ]; then
   echo "==> Existing checkout found; refreshing"
+  git -C "$RLMX_INSTALL_DIR" remote set-url origin "$RLMX_REPO_URL"
   git -C "$RLMX_INSTALL_DIR" fetch origin "$RLMX_BRANCH" --tags
-  git -C "$RLMX_INSTALL_DIR" checkout "$RLMX_BRANCH"
+  git -C "$RLMX_INSTALL_DIR" checkout -f "$RLMX_BRANCH"
   git -C "$RLMX_INSTALL_DIR" reset --hard "origin/$RLMX_BRANCH"
+  git -C "$RLMX_INSTALL_DIR" clean -fd
 else
   if [ -e "$RLMX_INSTALL_DIR" ]; then
     echo "error: $RLMX_INSTALL_DIR exists but is not a git checkout" >&2
@@ -31,7 +33,7 @@ fi
 cd "$RLMX_INSTALL_DIR"
 
 echo "==> Installing dependencies"
-npm ci
+npm ci --include=dev
 
 echo "==> Building"
 npm run build

--- a/scripts/smoke-install-update.sh
+++ b/scripts/smoke-install-update.sh
@@ -50,7 +50,7 @@ fi
   exit 1
 }
 
-npm pack --json --dry-run | node -e 'let s=""; process.stdin.on("data",d=>s+=d); process.stdin.on("end",()=>{ const p=JSON.parse(s)[0]; if (p.bin) { console.error("npm package exposes bin unexpectedly", p.bin); process.exit(1); } });' || {
+(cd "$ROOT" && npm pack --json --dry-run) | node -e 'let s=""; process.stdin.on("data",d=>s+=d); process.stdin.on("end",()=>{ const p=JSON.parse(s)[0]; if (p.bin) { console.error("npm package exposes bin unexpectedly", p.bin); process.exit(1); } });' || {
   echo "::error::npm package must remain SDK-only and expose no bin" >&2
   exit 1
 }
@@ -58,6 +58,7 @@ echo "==> npm package is SDK-only: no bin exposed"
 
 echo "==> Smoke update dirty-check refusal"
 printf '\n# dirty smoke\n' >> "$INSTALL_DIR/docs/release-contract.md"
+printf 'untracked smoke\n' > "$INSTALL_DIR/untracked-smoke.txt"
 if "$BIN_DIR/rlmx" update >"$TMP/dirty.out" 2>"$TMP/dirty.err"; then
   echo "::error::rlmx update succeeded despite dirty checkout" >&2
   cat "$TMP/dirty.out" >&2
@@ -70,18 +71,19 @@ if ! grep -q 'Refusing to update with local changes' "$TMP/dirty.err"; then
   exit 1
 fi
 
-git -C "$INSTALL_DIR" reset --hard HEAD >/dev/null
-git -C "$INSTALL_DIR" clean -fd >/dev/null
-
-echo "==> Smoke update happy path from advanced main"
+echo "==> Smoke update --force happy path from advanced main"
 printf '\nupdate-smoke=%s\n' "$(date -u +%Y%m%dT%H%M%SZ)" >> "$SOURCE/.rlmx-update-smoke"
 commit_source "test: advance main for update smoke"
 TARGET_HEAD="$(git -C "$SOURCE" rev-parse HEAD)"
 
-"$BIN_DIR/rlmx" update
+"$BIN_DIR/rlmx" update --force
 UPDATED_HEAD="$(git -C "$INSTALL_DIR" rev-parse HEAD)"
 if [ "$UPDATED_HEAD" != "$TARGET_HEAD" ]; then
   echo "::error::update head mismatch: installed=$UPDATED_HEAD source=$TARGET_HEAD" >&2
+  exit 1
+fi
+if [ -e "$INSTALL_DIR/untracked-smoke.txt" ]; then
+  echo "::error::rlmx update --force did not clean untracked files" >&2
   exit 1
 fi
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -942,7 +942,8 @@ async function runUpdate(args: string[]): Promise<void> {
   }
 
   runGit(root, ["reset", "--hard", "origin/main"]);
-  runCommand(root, "npm", ["ci"]);
+  runGit(root, ["clean", "-fd"]);
+  runCommand(root, "npm", ["ci", "--include=dev"]);
   runCommand(root, "npm", ["run", "build"]);
 
   const after = runGit(root, ["rev-parse", "HEAD"]);


### PR DESCRIPTION
## Summary

Follow-up to #103. I reviewed the PR comments and accepted the ones that were valid runtime/robustness findings.

Accepted fixes:
- Gemini: use `git checkout -f` during managed install refresh.
- CodeRabbit: refresh existing install `origin` to `RLMX_REPO_URL` before fetching.
- CodeRabbit: run SDK-only `npm pack --dry-run` assertion from repo root.
- CodeRabbit: make `rlmx update --force` clean untracked files after reset.
- Codex: use `npm ci --include=dev` in managed install/update paths so production `NODE_ENV` hosts can still build.

Smoke coverage extended:
- Dirty update refusal now includes an untracked file.
- Happy-path update uses `rlmx update --force` and asserts the untracked file was removed.

## Verification

- `npm run build`
- `npm run check`
- `npm test` — 377 passing, 0 failing
- `bash scripts/smoke-install-update.sh`
- push hook `npm run check`
