### PR TITLE
fix: use built-in token for rolling PR workflow

### DIFF
--- a/.github/workflows/rolling-pr.yml
+++ b/.github/workflows/rolling-pr.yml
@@ -20,12 +20,24 @@ jobs:
     steps:
       - name: Check/Create Rolling PR
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # Use the built-in workflow token. A stale custom token should not make
+          # the release-boundary helper fail with 401 on scheduled runs.
+          GH_TOKEN: ${{ github.token }}
         run: |
-          PR=$(gh pr list --repo ${{ github.repository }} --base main --head dev --state open --json number --jq '.[0].number')
+          set -euo pipefail
 
-          if [ -z "$PR" ]; then
-            gh pr create --repo ${{ github.repository }} \
+          PR=$(gh pr list --repo ${{ github.repository }} --base main --head dev --state open --json number --jq '.[0].number // ""')
+          if [ -n "$PR" ]; then
+            echo "Rolling PR #$PR exists and is up to date"
+            exit 0
+          fi
+
+          if [ "$(gh api repos/${{ github.repository }}/compare/main...dev --jq '.ahead_by')" = "0" ]; then
+            echo "dev has no commits ahead of main; no rolling PR needed"
+            exit 0
+          fi
+
+          gh pr create --repo ${{ github.repository }} \
               --base main --head dev \
               --title "chore: rolling promotion dev -> main" \
               --body "$(cat <<'BODY'
@@ -49,7 +61,4 @@ jobs:
           > Human approval required for merge to production.
           BODY
           )"
-            echo "Created new rolling PR"
-          else
-            echo "Rolling PR #$PR exists and is up to date"
-          fi
+          echo "Created new rolling PR"

--- a/docs/release-contract.md
+++ b/docs/release-contract.md
@@ -31,7 +31,9 @@ The npm package is SDK-only:
 
 ## Main release boundary
 
-`main` is the canonical release branch.
+`main` is the canonical release branch and the expected branch for long-lived production checkouts such as `/home/genie/prod/rlmx`.
+
+Use short-lived `drogo/<topic>` branches for focused source changes, then return the production checkout to `main` after merge/dogfood. Do not keep a long-lived `drogo/prod-rlmx` branch as the install/update authority.
 
 A release happens when a PR merges from `dev` to `main`:
 


### PR DESCRIPTION
## Summary

- switch Rolling PR Maintenance from stale `RELEASE_PLEASE_TOKEN` to `${{ github.token }}`
- make the helper exit cleanly when the `dev` -> `main` PR already exists or when `dev` is not ahead
- document that long-lived production RLMX checkouts track `main`; source work uses short-lived `drogo/<topic>` branches

## Verification

- PyYAML parsed `.github/workflows/rolling-pr.yml`
- extracted workflow shell passed `bash -n`
- security diff scan: no findings
- `npm run check`
- `npm test` — 377 passing, 0 failing
- independent reviewer: passed; no security concerns or logic errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release branch guidance, designating the main branch as the canonical release target.
  * Updated branching strategy documentation for focused development work and contribution guidelines.

* **Chores**
  * Enhanced automation workflow for improved reliability and robustness in rolling PR creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->